### PR TITLE
前端页面美化，修复客户端ID未回显问题

### DIFF
--- a/web/controllers/login.go
+++ b/web/controllers/login.go
@@ -30,6 +30,7 @@ func init() {
 	// use beego cache system store the captcha data
 	store := cache.NewMemoryCache()
 	cpt = captcha.NewWithFilter("/captcha/", store)
+	cpt.SetLength(4)
 }
 
 func (self *LoginController) Index() {

--- a/web/controllers/login.go
+++ b/web/controllers/login.go
@@ -30,7 +30,9 @@ func init() {
 	// use beego cache system store the captcha data
 	store := cache.NewMemoryCache()
 	cpt = captcha.NewWithFilter("/captcha/", store)
-	cpt.SetLength(4)
+	cpt.ChallengeNums = 4
+	cpt.StdWidth = 100
+	cpt.StdHeight = 50
 }
 
 func (self *LoginController) Index() {

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1966,23 +1966,23 @@ button:focus {
 }
 
 .btn-primary.btn-outline {
-    color: #1ab394;
+    color: #1ab394!important;
 }
 
 .btn-success.btn-outline {
-    color: #1c84c6;
+    color: #1c84c6!important;
 }
 
 .btn-info.btn-outline {
-    color: #23c6c8;
+    color: #23c6c8!important;
 }
 
 .btn-warning.btn-outline {
-    color: #f8ac59;
+    color: #f8ac59!important;
 }
 
 .btn-danger.btn-outline {
-    color: #ed5565;
+    color: #ed5565!important;
 }
 
 .btn-primary.btn-outline:hover,
@@ -1990,7 +1990,7 @@ button:focus {
 .btn-info.btn-outline:hover,
 .btn-warning.btn-outline:hover,
 .btn-danger.btn-outline:hover {
-    color: #fff;
+    color: #fff!important;
 }
 
 .btn.active,
@@ -7046,6 +7046,22 @@ body.mini-navbar.fixed-sidebar .logo-element {
 .loginColumns {
     max-width: 800px;
     margin: 0 auto;
+}
+
+.loginColumns input {
+    height: 36px;
+}
+
+.loginColumns .captcha-group {
+    display: flex;
+}
+
+.loginColumns .captcha-group .captcha {
+    margin-left: 15px;
+}
+
+.loginColumns .captcha-group .captcha img {
+    height: 36px;
 }
 
 .passwordBox {

--- a/web/static/page/languages.xml
+++ b/web/static/page/languages.xml
@@ -423,7 +423,7 @@
 		<en-US>Access address</en-US>
 	</lang>
 	<lang id="word-proxyprotocol">
-		<zh-CN>代理协议</zh-CN>
+		<zh-CN>代理协议 (Proxy Protocol)</zh-CN>
 		<en-US>Proxy Protocol</en-US>
 	</lang>
 	<lang id="word-disable">
@@ -431,11 +431,11 @@
 		<en-US>Disable</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv1">
-		<zh-CN>V1-字符串格式，支持 TCPv4、TCPv6</zh-CN>
+		<zh-CN>Proxy Protocol V1-字符串格式</zh-CN>
 		<en-US>Proxy Protocol v1</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv2">
-		<zh-CN>V2-二进制格式，支持 TCPv4、TCPv6、UDPv4、UDPv6</zh-CN>
+		<zh-CN>Proxy Protocol V2-二进制格式</zh-CN>
 		<en-US>Proxy Protocol v2</en-US>
 	</lang>
 	<lang id="word-proxytolocal">

--- a/web/static/page/languages.xml
+++ b/web/static/page/languages.xml
@@ -423,7 +423,7 @@
 		<en-US>Access address</en-US>
 	</lang>
 	<lang id="word-proxyprotocol">
-		<zh-CN>Proxy Protocol</zh-CN>
+		<zh-CN>代理协议</zh-CN>
 		<en-US>Proxy Protocol</en-US>
 	</lang>
 	<lang id="word-disable">
@@ -431,11 +431,11 @@
 		<en-US>Disable</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv1">
-		<zh-CN>Proxy Protocol v1</zh-CN>
+		<zh-CN>V1-字符串格式，支持 TCPv4、TCPv6</zh-CN>
 		<en-US>Proxy Protocol v1</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv2">
-		<zh-CN>Proxy Protocol v2</zh-CN>
+		<zh-CN>V2-二进制格式，支持 TCPv4、TCPv6、UDPv4、UDPv6</zh-CN>
 		<en-US>Proxy Protocol v2</en-US>
 	</lang>
 	<lang id="word-proxytolocal">

--- a/web/static/page/languages.xml
+++ b/web/static/page/languages.xml
@@ -431,11 +431,11 @@
 		<en-US>Disable</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv1">
-		<zh-CN>Proxy Protocol V1-字符串格式</zh-CN>
+		<zh-CN>V1-字符串格式</zh-CN>
 		<en-US>Proxy Protocol v1</en-US>
 	</lang>
 	<lang id="word-proxyprotocolv2">
-		<zh-CN>Proxy Protocol V2-二进制格式</zh-CN>
+		<zh-CN>V2-二进制格式</zh-CN>
 		<en-US>Proxy Protocol v2</en-US>
 	</lang>
 	<lang id="word-proxytolocal">

--- a/web/views/client/add.html
+++ b/web/views/client/add.html
@@ -125,7 +125,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('add', '{{.web_base_url}}/client/add', $('form').serializeArray())" type="button">

--- a/web/views/client/edit.html
+++ b/web/views/client/edit.html
@@ -141,7 +141,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('add', '{{.web_base_url}}/client/edit', $('form').serializeArray())" type="button">

--- a/web/views/index/add.html
+++ b/web/views/index/add.html
@@ -111,7 +111,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('add', '{{.web_base_url}}/index/add', $('form').serializeArray())" type="button">

--- a/web/views/index/edit.html
+++ b/web/views/index/edit.html
@@ -6,7 +6,7 @@
                 <form class="form-horizontal">
                     <input name="id" type="hidden" value="{{.t.Id}}">
                     <div class="form-group">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-scheme"></label>
+                        <label class="control-label font-bold" langtag="word-scheme"></label>
                         <div class="col-sm-10">
                             <span class="help-block m-b-none font-bold" langtag="word-usecase"></span>:
                             <span id="usecase">
@@ -31,34 +31,35 @@
                     </div>
 
                     <div class="form-group" id="client_id">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-clientid"></label>
+                        <label class="control-label font-bold" langtag="word-clientid"></label>
                         <div class="col-sm-10">
-                            <input class="form-control" langtag="word-clientid" name="client_id" placeholder="" type="text" value="{{.client_id}}" value="{{.t.Client.Id}}">
+                            <select class="form-control" langtag="word-clientid" name="client_id" placeholder=""></select>
+                            <!-- <input class="form-control" langtag="word-clientid" name="client_id" placeholder="" type="text" value="{{.t.Client.Id}}"> -->
                         </div>
                     </div>
 
                     <div class="form-group">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-remark"></label>
+                        <label class="control-label font-bold" langtag="word-remark"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="info-unrestricted" name="remark" placeholder="" type="text" value="{{.t.Remark}}">
                         </div>
                     </div>
                     {{if eq true .allow_multi_ip}}
                     <div class="form-group" id="server_ip">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-serverip"></label>
+                        <label class="control-label font-bold" langtag="word-serverip"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="info-suchasip" name="server_ip" placeholder="" type="text" value="{{.t.ServerIp}}">
                         </div>
                     </div>
                     {{end}}
                     <div class="form-group" id="port">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-serverport"></label>
+                        <label class="control-label font-bold" langtag="word-serverport"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="info-suchasport" name="port" placeholder="" type="text" value="{{.t.Port}}">
                         </div>
                     </div>
                     <div class="form-group" id="proxy_protocol">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-proxyprotocol"></label>
+                        <label class="control-label font-bold" langtag="word-proxyprotocol"></label>
                         <div class="col-sm-10">
                             <select class="form-control" name="proxy_protocol">
                                 <option value="0" {{if eq .t.Target.ProxyProtocol 0}}selected{{end}} langtag="word-disable"></option>
@@ -69,7 +70,7 @@
                     </div>
                     {{if eq true .allow_local_proxy}}
                     <div class="form-group" id="local_proxy">
-                        <label class="control-label col-sm-2 font-bold" langtag="word-proxytolocal"></label>
+                        <label class="control-label font-bold" langtag="word-proxytolocal"></label>
                         <div class="col-sm-10">
                             <select class="form-control" name="local_proxy">
                                 <option  {{if eq false .t.Target.LocalProxy}}selected{{end}} value="0" langtag="word-no"></option>
@@ -79,7 +80,7 @@
                     </div>
                     {{end}}
                     <div class="form-group" id="target">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-target"></label>
+                        <label class="control-label font-bold" langtag="word-target"></label>
                         <div class="col-sm-10">
                             <textarea class="form-control" langtag="info-suchasiplist" name="target" placeholder="" rows="4">{{.t.Target.TargetStr}}</textarea>
                             <span class="help-block m-b-none" langtag="info-targettunnel"></span>
@@ -87,21 +88,21 @@
                     </div>
 
                     <div class="form-group" id="local_path">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-localpath"></label>
+                        <label class="control-label font-bold" langtag="word-localpath"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="info-suchaslocalpath" name="local_path" placeholder="" type="text" value="{{.t.LocalPath}}">
                         </div>
                     </div>
 
                     <div class="form-group" id="strip_pre">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-stripprefix"></label>
+                        <label class="control-label font-bold" langtag="word-stripprefix"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="info-suchasstripprefix" name="strip_pre" placeholder="" type="text" value="{{.t.StripPre}}">
                         </div>
                     </div>
 
                     <div class="form-group" id="password">
-                        <label class="col-sm-2 control-label font-bold" langtag="word-identificationkey"></label>
+                        <label class="control-label font-bold" langtag="word-identificationkey"></label>
                         <div class="col-sm-10">
                             <input class="form-control" langtag="word-identificationkey" name="password" placeholder="" type="text" value="{{.t.Password}}">
                             <span class="help-block m-b-none" langtag="info-identificationkey"></span>
@@ -110,7 +111,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('edit', '{{.web_base_url}}/index/edit', $('form').serializeArray())" type="button">
@@ -155,5 +156,31 @@
         $("#use_client").on("change", function () {
             resetForm()
         })
+        
+        getClientList()
     })
+
+    function getClientList() {
+        const clientId = "{{if .t.Client.Id}}{{.t.Client.Id}}{{else}}{{.client_id}}{{end}}"; // 根据优先级选择
+        $("select[name='client_id']").empty();
+        $.ajax({
+            type: "POST",
+            url: "{{.web_base_url}}/client/list", // 服务器数据的加载地址
+            data: {order: "asc", offset: 0, limit: 999},
+            dataType: "json",
+            success: function (data) {
+                if (data && data.rows.length > 0) {
+                    for (var i = 0; i < data.rows.length; i++) {
+                        var option = "<option value=\"" + data.rows[i].Id + "\"";
+                        option += ">" + data.rows[i].Id + '-' + data.rows[i].Remark + "</option>"; // 动态添加数据
+                        $("select[name='client_id']").append(option);
+                    }
+                    // 设置选中项
+                    if (clientId) {
+                        $("select[name='client_id']").val(clientId);
+                    }
+                }
+            }
+        });
+    }
 </script>

--- a/web/views/index/hadd.html
+++ b/web/views/index/hadd.html
@@ -133,7 +133,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('add', '{{.web_base_url}}/index/addhost', $('form').serializeArray())" type="button">

--- a/web/views/index/hedit.html
+++ b/web/views/index/hedit.html
@@ -238,12 +238,12 @@
                 $("#key_file").css("display", "block")
             }
         })
-        
+
         getClientList()
     })
 
     function getClientList() {
-        const clientId = "{{if .t.Client.Id}}{{.t.Client.Id}}{{else}}{{.client_id}}{{end}}"; // 根据优先级选择
+        const clientId = "{{if .h.Client.Id}}{{.h.Client.Id}}{{else}}{{.client_id}}{{end}}"; // 根据优先级选择
         $("select[name='client_id']").empty();
         $.ajax({
             type: "POST",

--- a/web/views/index/hedit.html
+++ b/web/views/index/hedit.html
@@ -8,7 +8,8 @@
                     <div class="form-group">
                         <label class="control-label font-bold" langtag="word-clientid"></label>
                         <div class="col-sm-10">
-                            <input class="form-control" langtag="word-clientid" name="client_id" placeholder="" type="text" value="{{.h.Client.Id}}">
+                            <select class="form-control" langtag="word-clientid" name="client_id" placeholder=""></select>
+                            <!-- <input class="form-control" langtag="word-clientid" name="client_id" placeholder="" type="text" value="{{.h.Client.Id}}"> -->
                         </div>
                     </div>
                     <div class="form-group">
@@ -131,7 +132,7 @@
                     <div class="hr-line-dashed"></div>
                     <div class="form-group">
                         <div class="col-sm-4 col-sm-offset-2">
-                            <button class="btn btn-light" onclick="goback()" type="button">
+                            <button class="btn btn-secondary" onclick="goback()" type="button">
                                 <i class="fa fa-fw fa-lg fa-window-close"></i> <span langtag="word-cancel"></span>
                             </button>
                             <button class="btn btn-success" onclick="submitform('edit', '{{.web_base_url}}/index/edithost', $('form').serializeArray())" type="button">
@@ -237,5 +238,31 @@
                 $("#key_file").css("display", "block")
             }
         })
+        
+        getClientList()
     })
+
+    function getClientList() {
+        const clientId = "{{if .t.Client.Id}}{{.t.Client.Id}}{{else}}{{.client_id}}{{end}}"; // 根据优先级选择
+        $("select[name='client_id']").empty();
+        $.ajax({
+            type: "POST",
+            url: "{{.web_base_url}}/client/list", // 服务器数据的加载地址
+            data: {order: "asc", offset: 0, limit: 999},
+            dataType: "json",
+            success: function (data) {
+                if (data && data.rows.length > 0) {
+                    for (var i = 0; i < data.rows.length; i++) {
+                        var option = "<option value=\"" + data.rows[i].Id + "\"";
+                        option += ">" + data.rows[i].Id + '-' + data.rows[i].Remark + "</option>"; // 动态添加数据
+                        $("select[name='client_id']").append(option);
+                    }
+                    // 设置选中项
+                    if (clientId) {
+                        $("select[name='client_id']").val(clientId);
+                    }
+                }
+            }
+        });
+    }
 </script>

--- a/web/views/login/index.html
+++ b/web/views/login/index.html
@@ -57,9 +57,9 @@
                         <input class="form-control" langtag="word-password" name="password" placeholder="password" required="" type="password">
                     </div>
                     {{if eq true .captcha_open}}
-                    <div class="form-group">
-                        {{create_captcha}}
+                    <div class="form-group captcha-group">
                         <input class="form-control" langtag="word-captcha" name="captcha" placeholder="captcha" required="">
+                        {{create_captcha}}
                     </div>
                     {{end}}
                     <button class="btn btn-primary block full-width m-b" langtag="word-login" onclick="login()"></button>


### PR DESCRIPTION
+ 修复编辑域名转发时，客户端ID未回显问题
+ 修复TCP、UDP等编辑页面，客户端ID未回填问题；
+ 修复TCP、UDP等编辑页面，客户端采用下拉框进行选择；
+ TCP、UDP等编辑页面的label去掉col-sm-2,避免换行
+ 调整新增、编辑页面的返回按钮样式；
+ 将Proxy Protocol以及其选项汉化；
+ 调整列表页面的暂停、启用、删除按钮样式；