### PR TITLE
fix log formatting for file server lookup

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -347,7 +347,7 @@ func (s *TRPClient) handleChan(src net.Conn) {
 		key := strings.TrimPrefix(strings.TrimSpace(lk.Host), "file://")
 		vl, ok := s.fsm.GetListenerByKey(key)
 		if !ok {
-			logs.Warn("Fail to find file server: ", key)
+			logs.Warn("Fail to find file server: %s", key)
 			_ = src.Close()
 			return
 		}


### PR DESCRIPTION
## Summary
- fix log message format when file server is missing

## Testing
- `go test ./client`
- `go test ./...` *(fails: main redeclared in cmd/npc; Warn format mismatch in httpproxy; non-constant format string in cmd/nps; failing TestDealCommon)*

------
https://chatgpt.com/codex/tasks/task_e_68951abc39c0833185ace9ef11ae3dd9