### PR TITLE
修复深色背景下，分页按钮为浅色背景问题

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -2892,6 +2892,12 @@ button.dim:active:before {
     text-decoration: none;
 }
 
+.page-item.page-last-separator.disabled .page-link{
+    background-color: inherit;
+    border-color: var(--border-color);
+    color: inherit;
+}
+
 .page-item.active .page-link {
     background-color: #18b090;
     border-color: #18b090;


### PR DESCRIPTION
+ 修复深色背景下，分页按钮为浅色背景问题 #148 
+ 删除无用的CSS内容
+ 部分样式调整（分页按钮尺寸、隐藏关闭、收缩图标等）

![屏幕截图_4-9-2025_23196_localhost](https://github.com/user-attachments/assets/6ca49d5d-e957-4030-8a37-8d23c2222301)
↑修复后的效果