### PR TITLE
Fix mux new-conn channel close race

### DIFF
--- a/lib/mux/mux.go
+++ b/lib/mux/mux.go
@@ -281,6 +281,7 @@ func (s *Mux) readSession() {
 			s.connMap.Set(connection.connId, connection) //it has been Set before send ok
 			select {
 			case <-s.closeChan:
+				return
 			case s.newConnCh <- connection:
 			}
 			s.sendInfo(muxNewConnOk, connection.connId, false, nil)
@@ -431,7 +432,7 @@ func (s *Mux) Close() (err error) {
 		s.connMap.Close()
 		//s.connMap = nil
 		//s.closeChan <- struct{}{}
-		close(s.newConnCh)
+		// do not close newConnCh to avoid racing send on closed channel
 		// while target host close socket without finish steps, conn.Close method maybe blocked
 		// and tcp status change to CLOSE WAIT or TIME WAIT, so we close it in other goroutine
 		_ = s.conn.SetDeadline(time.Now().Add(time.Second * 5))


### PR DESCRIPTION
### Motivation
- Prevent a `panic: send on closed channel` that occurred when `Mux` is closed while the `readSession` goroutine can still send new connections to `newConnCh` under high-frequency mixed proxy (HTTP CONNECT) traffic.

### Description
- In `lib/mux/mux.go` update the `readSession` new-connection dispatch loop to return immediately when `closeChan` is signaled by adding `case <-s.closeChan: return` to the `select` that sends to `newConnCh`.
- Stop closing `newConnCh` in `Mux.Close()` to avoid send-on-closed races during shutdown and add a clarifying comment.

### Testing
- No automated tests were run.
