### PR TITLE
Clear bridge read deadlines before tunnel handling

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -566,6 +566,7 @@ func (s *Bridge) typeDeal(c *conn.Conn, id, ver int, vs string, first bool) {
 		}
 		uuid = crypt.GenerateUUID(uuid).String()
 	}
+	c.SetAlive()
 	isPub := file.GetDb().IsPubClient(id)
 	switch flag {
 	case common.WORK_MAIN:


### PR DESCRIPTION
### Motivation
- Prevent short handshake read deadlines from being inherited by long-lived tunnel/mux connections which can cause immediate EOF/close under high-frequency proxy traffic.

### Description
- Call `c.SetAlive()` after client verification and before handing the connection off to tunnel handling so any temporary read deadlines are cleared and the mux/tunnel won't be disconnected prematurely.

### Testing
- No automated tests were run for this change.

------
