### PR TITLE
Guard tunnel server close against nil listener

### DIFF
--- a/server/proxy/tcp.go
+++ b/server/proxy/tcp.go
@@ -52,6 +52,9 @@ func (s *TunnelModeServer) Close() error {
 		return true
 	})
 	s.activeConnections = sync.Map{}
+	if s.listener == nil {
+		return nil
+	}
 	return s.listener.Close()
 }
 


### PR DESCRIPTION
### Motivation
- Fix a nil pointer dereference crash when `TunnelModeServer.Close()` is invoked while the listener was not initialized.

### Description
- Add a guard in `TunnelModeServer.Close()` to check `s.listener == nil` and return early instead of calling `s.listener.Close()`.

### Testing
- No automated tests were run for this change.

------
