### PR TITLE
docs: 补全服务端配置项说明

### DIFF
--- a/docs/server_config.md
+++ b/docs/server_config.md
@@ -25,6 +25,7 @@ nps.exe -conf_path=D:\test\nps
 |----------------|----------------|
 | `appname`      | 应用名称           |
 | `runmode`      | 运行模式（dev/pro）  |
+| `secure_mode`  | 安全模式（默认 `true`，开启后不再兼容旧版客户端连接） |
 | `dns_server`   | DNS 服务器        |
 | `timezone`     | 时区             |
 | `ntp_server`   | NTP 服务器        |
@@ -45,6 +46,12 @@ nps.exe -conf_path=D:\test\nps
 | `web_base_url`      | Web 管理主路径（默认 `/`，适用于 Web 反向代理时调整路径）    |
 | `open_captcha`      | 是否启用验证码                                |
 | `pow_bits`          | PoW 验证位数（默认 `20`）                      |
+| `login_ban_time`    | 两次登录请求最小间隔（单位：秒，默认 `5`）                |
+| `login_ip_ban_time` | IP 维度失败次数重置周期（单位：秒，默认 `180`）            |
+| `login_user_ban_time` | 用户名维度失败次数重置周期（单位：秒，默认 `3600`）       |
+| `login_max_fail_times` | 最大允许登录失败次数（默认 `10`）                      |
+| `login_max_body`    | 登录请求体最大大小（单位：字节，默认 `1024`）            |
+| `login_max_skew`    | 时间戳偏移容忍度（单位：毫秒，默认 `300000`，即 5 分钟） |
 | `totp_secret`       | 两步验证密钥 开启后 `web_password` 失效 使用动态验证码登录 |
 | `allow_x_real_ip`   | 允许通过 X-Real-IP 头获取真实IP                 |
 | `trusted_proxy_ips` | 受信任的代理服务器 IP 地址（多个用逗号分隔）               |
@@ -63,6 +70,8 @@ nps.exe -conf_path=D:\test\nps
 | `http3_proxy_port`            | HTTP/3 代理监听端口（默认 `https_proxy_port`，配置`0`关闭）                                            |
 | `http_proxy_response_timeout` | HTTP 后端响应头超时（单位 s，默认值 100）                                                              |
 | `force_auto_ssl`              | 强制自动申请证书，需自行解决80、443端口问题（默认 `false`）                                                    |
+| `https_default_cert_file`     | HTTPS 代理默认证书文件路径（用于未单独配置证书的域名）                                                    |
+| `https_default_key_file`      | HTTPS 代理默认私钥文件路径                                                                    |
 | `ssl_path`                    | 自动申请证书保存路径（默认 `ssl`）                                                                    |
 | `ssl_email`                   | 自动申请证书使用的邮箱                                                                             |
 | `ssl_ca`                      | 自动申请证书使用的 CA（`LetsEncrypt`、`ZeroSSL`、`GoogleTrust`，默认 `LetsEncrypt`）                    |
@@ -90,6 +99,7 @@ nps.exe -conf_path=D:\test\nps
 | `bridge_key_file`             | 客户端与服务端通信 TLS 证书密钥文件路径                                                                  |
 | `bridge_http3`                | 客户端与服务端通信允许通过 HTTP/3 端口连接                                                               |
 | `bridge_select_mode`          | 相同`vkey`客户端连接选取模式（主备：`0`/`Primary`/`p`，轮询：`1`/`RoundRobin`/`rr`，随机：`2`/`Random`/`rand`） |
+| `bridge_addr`                 | Web 命令行中展示给客户端的连接地址（留空时自动使用 Web 访问地址）                                               |
 | `quic_alpn`                   | QUIC 握手时允许协商的 ALPN 列表，逗号分隔（默认 `nps`）                                                    |
 | `quic_keep_alive_period`      | QUIC 空闲保活周期（单位：s，默认 `10`）                                                               |
 | `quic_max_idle_timeout`       | QUIC 最大空闲超时时间（单位：秒，默认 `30`）                                                             |
@@ -192,6 +202,14 @@ server {
 | `system_info_display`        | 是否显示系统负载监控信息                              |
 | `disconnect_timeout`         | TCP 中断超时等待时间（单位 5s，默认值 60，即 300s = 5mins） |
 | `http_cache`                 | 是否启用 HTTP 缓存（已弃用，不再支持该功能）                 |
+
+---
+
+## 10. 调试配置
+| 名称         | 说明                              |
+|------------|---------------------------------|
+| `pprof_ip` | pprof 调试监听 IP（留空或注释表示关闭） |
+| `pprof_port` | pprof 调试监听端口（需与 `pprof_ip` 配合启用） |
 
 ---
 


### PR DESCRIPTION
### Motivation
- 同步 `conf/nps.conf` 中新增和已存在但缺失的配置项说明，确保文档与配置文件一致并便于运维和安全审查。
- 补充登录限频相关配置的说明以便管理员正确配置登录防护策略。

### Description
- 在 `docs/server_config.md` 中新增并说明了登录限频相关配置：`login_ban_time`、`login_ip_ban_time`、`login_user_ban_time`、`login_max_fail_times`、`login_max_body`、`login_max_skew`。
- 补充了其它文档中缺失的配置项说明：`secure_mode`、`https_default_cert_file`、`https_default_key_file` 和 `bridge_addr`。
- 新增“调试配置”章节并说明了 `pprof_ip` 与 `pprof_port` 的用途与启用方式。
- 仅修改了文档文件 `docs/server_config.md`，保持配置行为不变。

### Testing
- 运行了用于比对 `conf/nps.conf` 与文档的脚本（在仓库中以 Python 一次性运行），结果显示所有配置键已在文档中说明，脚本输出为 `missing 0`。
- 检查了变更范围以确认仅更新了 `docs/server_config.md`，未影响代码或运行时配置逻辑。

------
