### PR TITLE
Validate web API auth key with constant-time comparison and add unit tests

### DIFF
--- a/web/controllers/base.go
+++ b/web/controllers/base.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"crypto/subtle"
 	"html"
 	"html/template"
 	"math"
@@ -36,10 +37,7 @@ func (s *BaseController) Prepare() {
 	timestamp := s.GetIntNoErr("timestamp")
 	configKey := beego.AppConfig.String("auth_key")
 	timeNowUnix := common.TimeNow().Unix()
-	if configKey == "" {
-		configKey = crypt.GetRandomString(64)
-	}
-	if !(md5Key != "" && (math.Abs(float64(timeNowUnix-int64(timestamp))) <= 20) && (crypt.Md5(configKey+strconv.Itoa(timestamp)) == md5Key)) {
+	if !isValidAuthKey(configKey, md5Key, timestamp, timeNowUnix) {
 		if s.GetSession("auth") != true {
 			s.Redirect(beego.AppConfig.String("web_base_url")+"/login/index", 302)
 		}
@@ -71,6 +69,20 @@ func (s *BaseController) Prepare() {
 	s.Data["allow_user_local"] = beego.AppConfig.DefaultBool("allow_user_local", allowLocalProxy)
 	s.Data["allow_secret_link"], _ = beego.AppConfig.Bool("allow_secret_link")
 	s.Data["allow_user_change_username"], _ = beego.AppConfig.Bool("allow_user_change_username")
+}
+
+func isValidAuthKey(configKey, md5Key string, timestamp int, nowUnix int64) bool {
+	if configKey == "" || md5Key == "" {
+		return false
+	}
+	if math.Abs(float64(nowUnix-int64(timestamp))) > 20 {
+		return false
+	}
+	expected := crypt.Md5(configKey + strconv.Itoa(timestamp))
+	if len(expected) != len(md5Key) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(md5Key)) == 1
 }
 
 func (s *BaseController) display(tpl ...string) {

--- a/web/controllers/base_test.go
+++ b/web/controllers/base_test.go
@@ -1,0 +1,49 @@
+package controllers
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/djylb/nps/lib/crypt"
+)
+
+func TestIsValidAuthKey(t *testing.T) {
+	now := time.Now().Unix()
+	timestamp := int(now)
+	configKey := "test-config-key"
+	valid := crypt.Md5(configKey + strconv.Itoa(timestamp))
+
+	if !isValidAuthKey(configKey, valid, timestamp, now) {
+		t.Fatal("expected auth key to be valid")
+	}
+}
+
+func TestIsValidAuthKeyInvalidCases(t *testing.T) {
+	now := time.Now().Unix()
+	timestamp := int(now)
+	configKey := "test-config-key"
+	valid := crypt.Md5(configKey + strconv.Itoa(timestamp))
+
+	tests := []struct {
+		name      string
+		configKey string
+		md5Key    string
+		timestamp int
+		nowUnix   int64
+	}{
+		{name: "empty key", configKey: configKey, md5Key: "", timestamp: timestamp, nowUnix: now},
+		{name: "expired timestamp", configKey: configKey, md5Key: valid, timestamp: timestamp, nowUnix: now + 21},
+		{name: "length mismatch", configKey: configKey, md5Key: valid[:10], timestamp: timestamp, nowUnix: now},
+		{name: "wrong key", configKey: configKey, md5Key: crypt.Md5("wrong" + strconv.Itoa(timestamp)), timestamp: timestamp, nowUnix: now},
+		{name: "empty config key", configKey: "", md5Key: valid, timestamp: timestamp, nowUnix: now},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isValidAuthKey(tt.configKey, tt.md5Key, tt.timestamp, tt.nowUnix) {
+				t.Fatalf("expected auth key to be invalid for case %s", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Consolidate and harden the web API auth verification logic to avoid accidental bypass when `auth_key` is missing and to mitigate timing attacks.

### Description

- Extracted the auth validation logic into a new function `isValidAuthKey` and replaced the inline logic in `Prepare` to call it.
- Implemented constant-time comparison using `subtle.ConstantTimeCompare` and explicit checks for empty inputs and timestamp window (20 seconds).
- Removed the previous fallback that generated a random `configKey` when the configured `auth_key` was empty, so an empty `auth_key` no longer implicitly enables auth.
- Added unit tests in `web/controllers/base_test.go` covering a valid case and several invalid scenarios (`empty key`, `expired timestamp`, `length mismatch`, `wrong key`, and `empty config key`).

### Testing

- Ran the controller package tests with `go test ./web/controllers`, and the new tests `TestIsValidAuthKey` and `TestIsValidAuthKeyInvalidCases` passed.

------
