### PR TITLE
perf: precompile domain validation regexes

### DIFF
--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -30,6 +30,11 @@ import (
 	"github.com/djylb/nps/lib/logs"
 )
 
+var (
+	domainCheckWithPathRegexp = regexp.MustCompile(`^((http://)|(https://))?([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}(/)`)
+	domainCheckRegexp         = regexp.MustCompile(`^((http://)|(https://))?([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}`)
+)
+
 // ExtractHost
 // return "[2001:db8::1]:80"
 func ExtractHost(input string) string {
@@ -201,14 +206,7 @@ func GetHostByName(hostname string) string {
 
 // DomainCheck Check the legality of domain
 func DomainCheck(domain string) bool {
-	var match bool
-	IsLine := "^((http://)|(https://))?([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,6}(/)"
-	NotLine := "^((http://)|(https://))?([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,6}"
-	match, _ = regexp.MatchString(IsLine, domain)
-	if !match {
-		match, _ = regexp.MatchString(NotLine, domain)
-	}
-	return match
+	return domainCheckWithPathRegexp.MatchString(domain) || domainCheckRegexp.MatchString(domain)
 }
 
 func Max(values ...int) int {

--- a/lib/common/util_test.go
+++ b/lib/common/util_test.go
@@ -1,0 +1,25 @@
+package common
+
+import "testing"
+
+func TestDomainCheck(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{name: "plain domain", input: "example.com", valid: true},
+		{name: "http domain", input: "http://example.com", valid: true},
+		{name: "https domain with path", input: "https://example.com/path", valid: true},
+		{name: "invalid ip", input: "127.0.0.1", valid: false},
+		{name: "invalid string", input: "not_a_domain", valid: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DomainCheck(tc.input); got != tc.valid {
+				t.Fatalf("DomainCheck(%q) = %v, want %v", tc.input, got, tc.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Avoid recompiling domain-validation regular expressions on every call to `DomainCheck` to reduce runtime overhead in hot paths.

### Description

- Added package-level compiled regexes `domainCheckWithPathRegexp` and `domainCheckRegexp` in `lib/common/util.go` and replaced per-call `regexp.MatchString` usage with `MatchString` on the precompiled expressions. 
- Simplified `DomainCheck` to return the logical OR of the two precompiled regex matches.
- Added `lib/common/util_test.go` with table-driven unit tests for common valid and invalid domain inputs to ensure behavior is unchanged.

### Testing

- Ran `go test ./lib/common` and the package tests passed (`ok`).
- Ran `go test ./...` and observed unrelated failures in integration/environment-dependent tests due to missing `docker`/`tc` and port conflicts, and an existing failure in `lib/config`, so the global test run failed but the changes introduced here did not cause the failure.

------