### PR TITLE
fix: periodically prune login ban map to avoid memory growth

### DIFF
--- a/web/controllers/login.go
+++ b/web/controllers/login.go
@@ -29,6 +29,7 @@ var MaxLoginBody int64 = 1024
 var MaxSkew int64 = 5 * 60 * 1000
 
 var loginRecord sync.Map
+var loginRecordCleanerOnce sync.Once
 var cpt *captcha.Captcha
 var powBits int
 var secureMode bool
@@ -62,6 +63,7 @@ func InitLogin() {
 	MaxSkew = beego.AppConfig.DefaultInt64("login_max_skew", 5*60*1000)
 
 	rand.Seed(time.Now().UnixNano())
+	startLoginRecordCleaner()
 
 	// use beego cache system store the captcha data
 	store := cache.NewMemoryCache()
@@ -69,6 +71,18 @@ func InitLogin() {
 	cpt.ChallengeNums = 4
 	cpt.StdWidth = 100
 	cpt.StdHeight = 50
+}
+
+func startLoginRecordCleaner() {
+	loginRecordCleanerOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				CleanBanRecord(true)
+			}
+		}()
+	})
 }
 
 func (s *LoginController) Index() {


### PR DESCRIPTION
### Description
- 在 `web/controllers/login.go` 中新增 `loginRecordCleanerOnce` 和 `startLoginRecordCleaner()`，并在 `InitLogin()` 中调用以启动后台清理器。 
- 后台清理器启动单个 goroutine，使用 `time.NewTicker(time.Minute)` 每分钟调用 `CleanBanRecord(true)` 强制回收过期条目。 
- 使用 `sync.Once` 保证只启动一个清理协程，避免重复 goroutine 导致资源问题。 
- 仅修改文件: `web/controllers/login.go`，主要新增定时清理逻辑和相关变量。 

------
