### PR TITLE
fix: prevent P2P goroutine buildup, add Close and clear session timers

### DIFF
--- a/server/proxy/p2p.go
+++ b/server/proxy/p2p.go
@@ -57,7 +57,14 @@ func (s *P2PServer) Start() error {
 		data := make([]byte, n)
 		copy(data, buf[:n])
 		common.BufPoolUdp.Put(buf)
-		go s.handleP2P(addr, data)
+		s.handleP2P(addr, data)
+	}
+	return nil
+}
+
+func (s *P2PServer) Close() error {
+	if s.listener != nil {
+		return s.listener.Close()
 	}
 	return nil
 }
@@ -152,6 +159,7 @@ func (s *P2PServer) handleP2P(addr *net.UDPAddr, data []byte) {
 		logs.Trace("sent P2P addresses visitor=%v (%q) provider=%v (%q)", sess.visitorAddr, sess.visitorLocal, sess.providerAddr, sess.providerLocal)
 		if sess.timer != nil {
 			sess.timer.Stop()
+			sess.timer = nil
 		}
 		s.sessions.Delete(key)
 	} else {


### PR DESCRIPTION
### Motivation
- Prevent unbounded goroutine growth and memory retention in the server-side P2P handling under high UDP packet rates.
- Provide a clean way to close the P2P UDP listener during shutdown/reload to avoid dangling listener resources.
- Ensure session timers and other references don't keep session objects alive longer than necessary so garbage collection can reclaim memory.

### Description
- Replace per-packet `go s.handleP2P(...)` with inline `s.handleP2P(...)` in `server/proxy/p2p.go` to avoid spawning a goroutine for every received UDP packet.
- Add `P2PServer.Close()` which closes the UDP listener to allow clean shutdown of the P2P server.
- After stopping a session timer, set `sess.timer = nil` to remove the lingering reference to the timer and help GC reclaim session objects.

### Testing
- Ran `go test ./server/proxy ./bridge`, which completed successfully (packages contain no test files).
- Ran `go test ./bridge`, which completed successfully (package contains no test files).

------
