### PR TITLE
Capture loop variables when launching client goroutines in npc

### DIFF
--- a/cmd/npc/npc.go
+++ b/cmd/npc/npc.go
@@ -444,7 +444,7 @@ func run(ctx context.Context, cancel context.CancelFunc) {
 			localIP := localIPs[i]
 			connType = strings.ToLower(connType)
 
-			go func() {
+			go func(serverAddr, verifyKey, connType, localIP string) {
 				for {
 					logs.Info("Start server: %s vkey: %s type: %s local_ip: %s", serverAddr, verifyKey, connType, localIP)
 					client.NewRPClient(serverAddr, verifyKey, connType, *proxyUrl, localIP, "", nil, *disconnectTime, nil).Start(ctx)
@@ -458,7 +458,7 @@ func run(ctx context.Context, cancel context.CancelFunc) {
 						return
 					}
 				}
-			}()
+			}(serverAddr, verifyKey, connType, localIP)
 		}
 	}
 	if *configPath != "" || !hasCommand {


### PR DESCRIPTION
### Motivation
- Prevent incorrect closure capture of loop variables when spawning multiple client goroutines so each goroutine uses the intended `serverAddr`, `verifyKey`, `connType`, and `localIP` values.

### Description
- Change the anonymous goroutine to accept parameters `(serverAddr, verifyKey, connType, localIP string)` and pass the current loop variables when invoking it to ensure per-iteration value capture.

### Testing
- Ran `go test ./...` and `go build ./cmd/npc` which both completed successfully.

------
