### PR TITLE
Adjust client list toolbar button spacing and ping button style

### DIFF
--- a/web/views/client/list.html
+++ b/web/views/client/list.html
@@ -21,10 +21,10 @@
                                 <a class="btn btn-primary dim mr-2" href="{{.web_base_url}}/client/add">
                                     <i class="fa fa-fw fa-lg fa-plus"></i>
                                     <span langtag="word-add"></span></a>
-                                <a class="btn btn-danger dim" onclick="submitform('clear', '{{.web_base_url}}/client/clear', {'id': 0, 'mode': 'flow'})">
+                                <a class="btn btn-danger dim mr-2" onclick="submitform('clear', '{{.web_base_url}}/client/clear', {'id': 0, 'mode': 'flow'})">
                                     <i class="fa fa-fw fa-lg fa-eraser"></i>
                                     <span langtag="word-clearflow"></span></a>
-                                <a class="btn btn-info dim ml-2" onclick="triggerVisibleClientPing(this)">
+                                <a class="btn btn-warning dim" onclick="triggerVisibleClientPing(this)">
                                     <i class="fa fa-fw fa-lg fa-signal"></i>
                                     <span langtag="word-ping"></span></a>
                             </div>


### PR DESCRIPTION
### Motivation
- Tweak the client list toolbar UI for consistent spacing and clearer visual emphasis on the ping action in `web/views/client/list.html`.

### Description
- Added `mr-2` spacing to the clear button and removed the left margin from the ping button while changing its style from `btn-info` to `btn-warning` in `web/views/client/list.html`.

### Testing
- No automated tests were run or modified for this small template-only change.

------
