### PR TITLE
Optimize WsConn reads to reduce peak memory allocations

### DIFF
--- a/lib/conn/websocket.go
+++ b/lib/conn/websocket.go
@@ -14,36 +14,45 @@ import (
 
 type WsConn struct {
 	*websocket.Conn
-	RealIP  string
-	readBuf []byte
+	RealIP    string
+	readFrame io.Reader
 }
 
 func NewWsConn(ws *websocket.Conn) *WsConn {
-	return &WsConn{Conn: ws, readBuf: make([]byte, 0)}
+	return &WsConn{Conn: ws}
 }
 
 func (c *WsConn) Read(p []byte) (int, error) {
-	if len(c.readBuf) > 0 {
-		n := copy(p, c.readBuf)
-		c.readBuf = c.readBuf[n:]
-		return n, nil
+	if len(p) == 0 {
+		return 0, nil
 	}
-	mt, r, err := c.NextReader()
-	if err != nil {
-		return 0, err
+
+	for {
+		if c.readFrame == nil {
+			mt, r, err := c.NextReader()
+			if err != nil {
+				return 0, err
+			}
+			if mt == websocket.CloseMessage {
+				return 0, io.EOF
+			}
+			c.readFrame = r
+		}
+
+		n, err := c.readFrame.Read(p)
+		switch {
+		case n > 0 && err == io.EOF:
+			c.readFrame = nil
+			return n, nil
+		case n > 0:
+			return n, err
+		case err == io.EOF:
+			c.readFrame = nil
+			continue
+		default:
+			return 0, err
+		}
 	}
-	if mt == websocket.CloseMessage {
-		return 0, io.EOF
-	}
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return 0, err
-	}
-	n := copy(p, data)
-	if n < len(data) {
-		c.readBuf = append(c.readBuf, data[n:]...)
-	}
-	return n, nil
 }
 
 func (c *WsConn) Write(p []byte) (int, error) {

--- a/lib/conn/websocket_test.go
+++ b/lib/conn/websocket_test.go
@@ -1,0 +1,72 @@
+package conn
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestWsConnReadStreamsAcrossCalls(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	msg := []byte("0123456789")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade failed: %v", err)
+		}
+		defer ws.Close()
+		_ = ws.SetWriteDeadline(time.Now().Add(2 * time.Second))
+		if err = ws.WriteMessage(websocket.BinaryMessage, msg); err != nil {
+			t.Fatalf("write message failed: %v", err)
+		}
+		_ = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	}))
+	defer server.Close()
+
+	dialer := websocket.Dialer{}
+	url := "ws" + server.URL[len("http"):]
+	client, _, err := dialer.Dial(url, nil)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer client.Close()
+
+	conn := NewWsConn(client)
+	buf := make([]byte, 4)
+
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("first read failed: %v", err)
+	}
+	if got := string(buf[:n]); got != "0123" {
+		t.Fatalf("first read mismatch: got %q", got)
+	}
+
+	n, err = conn.Read(buf)
+	if err != nil {
+		t.Fatalf("second read failed: %v", err)
+	}
+	if got := string(buf[:n]); got != "4567" {
+		t.Fatalf("second read mismatch: got %q", got)
+	}
+
+	n, err = conn.Read(buf)
+	if err != nil {
+		t.Fatalf("third read failed: %v", err)
+	}
+	if got := string(buf[:n]); got != "89" {
+		t.Fatalf("third read mismatch: got %q", got)
+	}
+
+	_, err = conn.Read(buf)
+	if err == nil {
+		t.Fatal("expected EOF after close frame")
+	}
+	if err != io.EOF && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		t.Fatalf("expected EOF or close-normal error, got: %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Reduce peak memory usage when reading large websocket frames by avoiding full-frame buffering and extra allocations.
- Preserve existing Read semantics (partial reads across multiple calls and proper close-frame behavior) while minimizing temporary copies.
- Add a targeted test to prevent regressions in multi-call frame reads and post-close behavior.

### Description

- Replace per-frame `io.ReadAll` + leftover slice buffering with an incremental reader stored as `readFrame io.Reader` on `WsConn` so frames are consumed via `Read` directly from `NextReader` without full-frame allocation (`lib/conn/websocket.go`).
- Remove the `readBuf` byte-slice and add a zero-length-read fast path to keep semantics stable and predictable.
- Add `lib/conn/websocket_test.go` to exercise partial reads across multiple `Read` calls and verify EOF/close-frame handling.

### Testing

- Added and ran unit tests in `lib/conn` via `go test ./lib/conn`, which completed successfully (`ok`).
- The new `TestWsConnReadStreamsAcrossCalls` verifies partial reads across multiple `Read` calls and behavior after the server sends a close frame. 
- No other packages were modified and the change is localized to websocket read path to limit risk.

------
