### PR TITLE
Optimize common binary encoding to reduce allocations

### DIFF
--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -503,20 +503,27 @@ func TestUdpPort(port int) bool {
 // # Characters are used to separate data
 func BinaryWrite(raw *bytes.Buffer, v ...string) {
 	b := GetWriteStr(v...)
-	_ = binary.Write(raw, binary.LittleEndian, int32(len(b)))
-	_ = binary.Write(raw, binary.LittleEndian, b)
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(len(b)))
+	_, _ = raw.Write(lenBuf[:])
+	_, _ = raw.Write(b)
 }
 
 // GetWriteStr get seq str
 func GetWriteStr(v ...string) []byte {
-	buffer := new(bytes.Buffer)
-	var l int32
-	for _, v := range v {
-		l += int32(len([]byte(v))) + int32(len([]byte(CONN_DATA_SEQ)))
-		_ = binary.Write(buffer, binary.LittleEndian, []byte(v))
-		_ = binary.Write(buffer, binary.LittleEndian, []byte(CONN_DATA_SEQ))
+	sep := CONN_DATA_SEQ
+	sepLen := len(sep)
+	total := 0
+	for _, s := range v {
+		total += len(s) + sepLen
 	}
-	return buffer.Bytes()
+
+	buffer := make([]byte, 0, total)
+	for _, s := range v {
+		buffer = append(buffer, s...)
+		buffer = append(buffer, sep...)
+	}
+	return buffer
 }
 
 // InStrArr inArray str interface

--- a/lib/common/util_test.go
+++ b/lib/common/util_test.go
@@ -1,6 +1,10 @@
 package common
 
-import "testing"
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
 
 func TestDomainCheck(t *testing.T) {
 	tests := []struct {
@@ -21,5 +25,34 @@ func TestDomainCheck(t *testing.T) {
 				t.Fatalf("DomainCheck(%q) = %v, want %v", tc.input, got, tc.valid)
 			}
 		})
+	}
+}
+
+func TestGetWriteStr(t *testing.T) {
+	got := GetWriteStr("alpha", "beta")
+	want := []byte("alpha" + CONN_DATA_SEQ + "beta" + CONN_DATA_SEQ)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("GetWriteStr() = %q, want %q", string(got), string(want))
+	}
+}
+
+func TestBinaryWrite(t *testing.T) {
+	raw := bytes.NewBuffer(nil)
+	BinaryWrite(raw, "info", "true")
+
+	buf := raw.Bytes()
+	if len(buf) < 4 {
+		t.Fatalf("BinaryWrite() output too short: %d", len(buf))
+	}
+
+	payloadLen := int(binary.LittleEndian.Uint32(buf[:4]))
+	payload := buf[4:]
+	if payloadLen != len(payload) {
+		t.Fatalf("payload length = %d, want %d", payloadLen, len(payload))
+	}
+
+	want := []byte("info" + CONN_DATA_SEQ + "true" + CONN_DATA_SEQ)
+	if !bytes.Equal(payload, want) {
+		t.Fatalf("payload = %q, want %q", string(payload), string(want))
 	}
 }


### PR DESCRIPTION
### Motivation
- Reduce memory allocations and temporary buffering in the common binary encoding path used by connection messaging, while keeping behavior and performance unchanged.

### Description
- Replace `BinaryWrite` use of `binary.Write` with a direct 4-byte little-endian length header written via `binary.LittleEndian.PutUint32` followed by the payload written with `raw.Write` to avoid reflection and extra allocations.
- Rewrite `GetWriteStr` to compute total capacity then `make([]byte, 0, total)` and `append` strings and the separator (`CONN_DATA_SEQ`) directly to avoid `bytes.Buffer` and repeated `binary.Write` calls.
- Add unit tests `TestGetWriteStr` and `TestBinaryWrite` in `lib/common/util_test.go` to verify encoding format and that the prepended length matches the payload length.
- Modified files: `lib/common/util.go` and `lib/common/util_test.go`.

### Testing
- Ran `go test ./lib/common`, which passed: `ok   github.com/djylb/nps/lib/common  0.033s`.
- New tests `TestGetWriteStr` and `TestBinaryWrite` executed as part of the package tests and succeeded.

------
