### PR TITLE
Reduce per-packet allocations in P2P UDP receive path

### DIFF
--- a/server/proxy/p2p.go
+++ b/server/proxy/p2p.go
@@ -48,16 +48,14 @@ func (s *P2PServer) Start() error {
 		buf := common.BufPoolUdp.Get().([]byte)
 		n, addr, err := s.listener.ReadFromUDP(buf)
 		if err != nil {
-			common.BufPoolUdp.Put(buf)
+			common.PutBufPoolUdp(buf)
 			if strings.Contains(err.Error(), "use of closed network connection") {
 				break
 			}
 			continue
 		}
-		data := make([]byte, n)
-		copy(data, buf[:n])
-		common.BufPoolUdp.Put(buf)
-		s.handleP2P(addr, data)
+		s.handleP2P(addr, buf[:n])
+		common.PutBufPoolUdp(buf)
 	}
 	return nil
 }


### PR DESCRIPTION
### Motivation
- Reduce transient heap allocations and GC pressure in the P2P UDP receive loop by avoiding per-packet `make`+`copy` and keeping buffer pooling semantics consistent.

### Description
- In `server/proxy/p2p.go` pass the received slice view `buf[:n]` directly to `handleP2P` instead of allocating and copying into a new `[]byte`, and replace direct `BufPoolUdp.Put` usage with the centralized `common.PutBufPoolUdp` for consistent pool returns.

### Testing
- Ran `gofmt -w server/proxy/p2p.go`, which completed successfully.
- Ran `go test ./server/proxy/...`, which succeeded (package has no test files); a full `go test ./...` was also executed and reported an existing unrelated failure `lib/config: TestDealCommon` that is not caused by this change.

------
