### PR TITLE
Optimize memory usage in paginated list retrieval paths

### DIFF
--- a/lib/file/db.go
+++ b/lib/file/db.go
@@ -51,9 +51,14 @@ func GetMapKeys(m *sync.Map, isSort bool, sortKey, order string) (keys []int) {
 }
 
 func (s *DbUtils) GetClientList(start, length int, search, sort, order string, clientId int) ([]*Client, int) {
-	list := make([]*Client, 0)
+	resultCap := 0
+	if length > 0 {
+		resultCap = length
+	}
+	list := make([]*Client, 0, resultCap)
 	var cnt int
 	originLength := length
+	searchInt := common.GetIntNoErrByStr(search)
 	keys := GetMapKeys(&s.JsonDb.Clients, true, sort, order)
 	for _, key := range keys {
 		if value, ok := s.JsonDb.Clients.Load(key); ok {
@@ -64,7 +69,7 @@ func (s *DbUtils) GetClientList(start, length int, search, sort, order string, c
 			if clientId != 0 && clientId != v.Id {
 				continue
 			}
-			if search != "" && !(v.Id == common.GetIntNoErrByStr(search) || common.ContainsFold(v.VerifyKey, search) || common.ContainsFold(v.Remark, search)) {
+			if search != "" && !(v.Id == searchInt || common.ContainsFold(v.VerifyKey, search) || common.ContainsFold(v.Remark, search)) {
 				continue
 			}
 			cnt++
@@ -337,14 +342,19 @@ func (s *DbUtils) NewHost(t *Host) error {
 }
 
 func (s *DbUtils) GetHost(start, length int, id int, search string) ([]*Host, int) {
-	list := make([]*Host, 0)
+	resultCap := 0
+	if length > 0 {
+		resultCap = length
+	}
+	list := make([]*Host, 0, resultCap)
 	var cnt int
 	originLength := length
+	searchInt := common.GetIntNoErrByStr(search)
 	keys := GetMapKeys(&s.JsonDb.Hosts, false, "", "")
 	for _, key := range keys {
 		if value, ok := s.JsonDb.Hosts.Load(key); ok {
 			v := value.(*Host)
-			if search != "" && !(v.Id == common.GetIntNoErrByStr(search) || common.ContainsFold(v.Host, search) || common.ContainsFold(v.Remark, search) || common.ContainsFold(v.Client.VerifyKey, search)) {
+			if search != "" && !(v.Id == searchInt || common.ContainsFold(v.Host, search) || common.ContainsFold(v.Remark, search) || common.ContainsFold(v.Client.VerifyKey, search)) {
 				continue
 			}
 			if id == 0 || v.Client.Id == id {

--- a/server/server.go
+++ b/server/server.go
@@ -331,11 +331,16 @@ func DelTask(id int) error {
 
 // GetTunnel get task list by page num
 func GetTunnel(start, length int, typeVal string, clientId int, search string, sortField string, order string) ([]*file.Tunnel, int) {
-	allList := make([]*file.Tunnel, 0) //store all Tunnel
-	list := make([]*file.Tunnel, 0)
-	originLength := length
-	var cnt int
 	keys := file.GetMapKeys(&file.GetDb().JsonDb.Tasks, false, "", "")
+	allList := make([]*file.Tunnel, 0, len(keys)) //store all Tunnel
+	resultCap := 0
+	if length > 0 {
+		resultCap = length
+	}
+	list := make([]*file.Tunnel, 0, resultCap)
+	originLength := length
+	searchInt := common.GetIntNoErrByStr(search)
+	var cnt int
 
 	//get all Tunnel and sort
 	for _, key := range keys {
@@ -506,7 +511,7 @@ func GetTunnel(start, length int, typeVal string, clientId int, search string, s
 			if (typeVal != "" && v.Mode != typeVal || (clientId != 0 && v.Client.Id != clientId)) || (typeVal == "" && clientId != v.Client.Id) {
 				continue
 			}
-			if search != "" && !(v.Id == common.GetIntNoErrByStr(search) || v.Port == common.GetIntNoErrByStr(search) || common.ContainsFold(v.Password, search) || common.ContainsFold(v.Remark, search) || common.ContainsFold(v.Target.TargetStr, search)) {
+			if search != "" && !(v.Id == searchInt || v.Port == searchInt || common.ContainsFold(v.Password, search) || common.ContainsFold(v.Remark, search) || common.ContainsFold(v.Target.TargetStr, search)) {
 				continue
 			}
 			cnt++


### PR DESCRIPTION
### Motivation
- Reduce transient heap allocations in common list API paths that are hit frequently during pagination and filtering.
- Make low-risk changes that avoid impacting request throughput or sorting semantics.

### Description
- Pre-allocate result slices in `GetClientList`, `GetHost`, and `GetTunnel` according to the requested `length` to reduce repeated `append`-driven reallocations (`lib/file/db.go`, `server/server.go`).
- Pre-allocate `allList` in `GetTunnel` using the known key count from `file.GetMapKeys` to avoid repeated growth while collecting tasks (`server/server.go`).
- Parse `search` once per request with `common.GetIntNoErrByStr(search)` and reuse the integer (`searchInt`) in loop filters instead of calling the parser on every item to reduce temporary allocations (`lib/file/db.go`, `server/server.go`).

### Testing
- Ran `go test ./lib/file ./server` which completed successfully (no test files for some packages reported as expected).
- Ran `timeout 120 go test ./server/...` which completed successfully for server packages.
- Ran `go test ./lib/... ./server/...` and observed a pre-existing failing test `TestDealCommon` in `lib/config` that is unrelated to these changes.

------
