### PR TITLE
Optimize UDPDatagram.Write to use pooled buffer and add unit tests

### DIFF
--- a/lib/common/netpackager.go
+++ b/lib/common/netpackager.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -218,16 +217,42 @@ func (d *UDPDatagram) Write(w io.Writer) error {
 	if h == nil {
 		h = &UDPHeader{}
 	}
-	buf := bytes.Buffer{}
-	if err := h.Write(&buf); err != nil {
-		return err
+
+	b := BufPoolUdp.Get().([]byte)
+	defer BufPoolUdp.Put(b)
+
+	binary.BigEndian.PutUint16(b[:2], h.Rsv)
+	b[2] = h.Frag
+
+	addr := h.Addr
+	if addr == nil {
+		addr = &Addr{}
 	}
-	if _, err := buf.Write(d.Data); err != nil {
-		return err
+	headerLen, _ := addr.Encode(b[3:])
+	headerLen += 3
+	total := headerLen + len(d.Data)
+
+	var packet []byte
+	if total <= len(b) {
+		packet = b[:total]
+	} else {
+		packet = make([]byte, total)
+		copy(packet[:headerLen], b[:headerLen])
 	}
 
-	_, err := buf.WriteTo(w)
-	return err
+	copy(packet[headerLen:], d.Data)
+
+	for len(packet) > 0 {
+		n, err := w.Write(packet)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		packet = packet[n:]
+	}
+	return nil
 }
 
 // trim IPv6 zone if any (e.g., "fe80::1%eth0" -> "fe80::1")

--- a/lib/common/netpackager_test.go
+++ b/lib/common/netpackager_test.go
@@ -1,0 +1,99 @@
+package common
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+type countingWriter struct {
+	writes int
+	buf    bytes.Buffer
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.writes++
+	return w.buf.Write(p)
+}
+
+func TestUDPDatagramWriteMatchesSocksFormat(t *testing.T) {
+	d := &UDPDatagram{
+		Header: &UDPHeader{
+			Rsv:  0,
+			Frag: 0,
+			Addr: &Addr{Type: domainName, Host: "example.com", Port: 8080},
+		},
+		Data: []byte("payload"),
+	}
+
+	var out bytes.Buffer
+	if err := d.Write(&out); err != nil {
+		t.Fatalf("UDPDatagram.Write() error = %v", err)
+	}
+
+	got := out.Bytes()
+	if len(got) < 7 {
+		t.Fatalf("UDPDatagram.Write() produced short packet: %d", len(got))
+	}
+
+	if rsv := binary.BigEndian.Uint16(got[:2]); rsv != 0 {
+		t.Fatalf("RSV = %d, want 0", rsv)
+	}
+	if got[2] != 0 {
+		t.Fatalf("FRAG = %d, want 0", got[2])
+	}
+	if got[3] != domainName {
+		t.Fatalf("ATYP = %d, want %d", got[3], domainName)
+	}
+	if got[4] != byte(len("example.com")) {
+		t.Fatalf("domain length = %d, want %d", got[4], len("example.com"))
+	}
+
+	offset := 5
+	hostEnd := offset + len("example.com")
+	if host := string(got[offset:hostEnd]); host != "example.com" {
+		t.Fatalf("host = %q, want %q", host, "example.com")
+	}
+	if port := binary.BigEndian.Uint16(got[hostEnd : hostEnd+2]); port != 8080 {
+		t.Fatalf("port = %d, want %d", port, 8080)
+	}
+	if payload := string(got[hostEnd+2:]); payload != "payload" {
+		t.Fatalf("payload = %q, want %q", payload, "payload")
+	}
+}
+
+func TestUDPDatagramWriteSupportsNilHeader(t *testing.T) {
+	d := &UDPDatagram{Data: []byte("x")}
+
+	var out bytes.Buffer
+	if err := d.Write(&out); err != nil {
+		t.Fatalf("UDPDatagram.Write() error with nil header = %v", err)
+	}
+
+	got := out.Bytes()
+	if len(got) != 11 { // RSV(2)+FRAG(1)+ATYP(1)+IPv4(4)+PORT(2)+payload(1)
+		t.Fatalf("packet length = %d, want 11", len(got))
+	}
+	if got[3] != ipV4 {
+		t.Fatalf("ATYP = %d, want %d", got[3], ipV4)
+	}
+	if !net.IP(got[4:8]).Equal(net.IPv4zero) {
+		t.Fatalf("ip = %v, want %v", net.IP(got[4:8]), net.IPv4zero)
+	}
+}
+
+func TestUDPDatagramWriteUsesSingleWriteCall(t *testing.T) {
+	d := &UDPDatagram{
+		Header: &UDPHeader{Addr: &Addr{Type: ipV4, Host: "127.0.0.1", Port: 80}},
+		Data:   []byte("abc"),
+	}
+
+	w := &countingWriter{}
+	if err := d.Write(w); err != nil {
+		t.Fatalf("UDPDatagram.Write() error = %v", err)
+	}
+	if w.writes != 1 {
+		t.Fatalf("write calls = %d, want 1", w.writes)
+	}
+}


### PR DESCRIPTION
### Motivation
- Reduce allocations and avoid building a temporary `bytes.Buffer` when serializing UDP datagrams.  
- Ensure `UDPDatagram.Write` produces correct SOCKS-style datagrams and handles partial writes and nil headers robustly.  

### Description
- Replaced use of `bytes.Buffer` in `UDPDatagram.Write` with a pooled byte slice (`BufPoolUdp`) and direct header encoding via `binary.BigEndian` and `Addr.Encode`.  
- Precompute `headerLen` and attempt to write into the pooled buffer, falling back to a freshly allocated slice only when the packet exceeds the pooled size.  
- Implement a write loop that handles partial `Write` returns and returns `io.ErrShortWrite` for zero-length writes.  
- Removed unused `bytes` import and added unit tests in `netpackager_test.go` covering format correctness, nil-header behavior, and write call counting.  

### Testing
- Added `TestUDPDatagramWriteMatchesSocksFormat` which validates the produced datagram fields and payload, and it passed.  
- Added `TestUDPDatagramWriteSupportsNilHeader` which validates default header encoding for a nil header, and it passed.  
- Added `TestUDPDatagramWriteUsesSingleWriteCall` which asserts the write-call behavior and it passed when running `go test` for the package.

------
