### PR TITLE
Optimize copy buffer pool reuse to reduce allocations

### DIFF
--- a/lib/common/pool.go
+++ b/lib/common/pool.go
@@ -76,10 +76,8 @@ func (Self *copyBufferPool) Get() []byte {
 }
 
 func (Self *copyBufferPool) Put(x []byte) {
-	if len(x) == PoolSizeCopy {
-		Self.pool.Put(x)
-	} else {
-		x = nil // buf is not full, not allowed, New method returns a full buf
+	if cap(x) == PoolSizeCopy {
+		Self.pool.Put(x[:PoolSizeCopy])
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Reduce unnecessary allocations and GC pressure by ensuring buffers obtained from the copy buffer pool are actually reused even if they were passed around as subslices. 
- The previous `Put` guarded on `len(x) == PoolSizeCopy`, which rejected valid pooled buffers that had been resliced to a shorter length during I/O operations.

### Description
- Change `copyBufferPool.Put` in `lib/common/pool.go` to check `cap(x) == PoolSizeCopy` and normalize the slice to `x[:PoolSizeCopy]` before returning it to the pool. 
- This allows subslices that retain the original capacity to be accepted back into the pool and reused by `CopyBuff.Get()` and callers like `CopyBuffer`/`io.CopyBuffer`.

### Testing
- Ran `go test ./lib/common ./lib/conn ./lib/goroutine ./server/proxy/...` and the targeted packages passed. 
- A full `go test ./...` was attempted and surfaced an unrelated existing test failure in `lib/config` (`TestDealCommon`), which is not caused by this change.

------
