### PR TITLE
test(config): repair and extend Common config unit tests

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"regexp"
 	"testing"
 )
@@ -43,21 +42,65 @@ p=2
 `
 	re, err := regexp.Compile(`\[.+?\]`)
 	if err != nil {
-		t.Fail()
+		t.Fatalf("compile regexp failed: %v", err)
 	}
-	log.Println(re.FindAllString(content, -1))
+	all := re.FindAllString(content, -1)
+	if len(all) != 5 {
+		t.Fatalf("unexpected title count: %d", len(all))
+	}
 }
 
 func TestDealCommon(t *testing.T) {
-	s := `server=127.0.0.1:8284
-tp=tcp
-vkey=123`
-	f := new(CommonConfig)
-	f.Server = "127.0.0.1:8284"
-	f.Tp = "tcp"
-	f.VKey = "123"
-	if c := dealCommon(s); *c != *f {
-		t.Fail()
+	s := `server_addr=127.0.0.1:8284
+conn_type=kcp
+vkey=123
+auto_reconnection=false
+basic_username=admin
+basic_password=pass
+compress=false
+crypt=false
+web_username=user
+web_password=web-pass
+rate_limit=1024
+flow_limit=2048
+max_conn=12
+disconnect_timeout=30
+tls_enable=true`
+
+	c := dealCommon(s)
+	if c.Server != "127.0.0.1:8284" || c.Tp != "kcp" || c.VKey != "123" {
+		t.Fatalf("basic common fields parse failed: %+v", c)
+	}
+	if c.AutoReconnection {
+		t.Fatalf("auto_reconnection should be false")
+	}
+	if c.Client == nil || c.Client.Cnf == nil {
+		t.Fatalf("client or client config not initialized")
+	}
+	if c.Client.Cnf.U != "admin" || c.Client.Cnf.P != "pass" {
+		t.Fatalf("basic auth parse failed: %+v", c.Client.Cnf)
+	}
+	if c.Client.WebUserName != "user" || c.Client.WebPassword != "web-pass" {
+		t.Fatalf("web auth parse failed: %+v", c.Client)
+	}
+	if c.Client.RateLimit != 1024 || c.Client.Flow.FlowLimit != 2048 || c.Client.MaxConn != 12 {
+		t.Fatalf("limit fields parse failed: %+v", c.Client)
+	}
+	if c.DisconnectTime != 30 || !c.TlsEnable {
+		t.Fatalf("disconnect or tls parse failed: %+v", c)
+	}
+}
+
+func TestDealCommon_Defaults(t *testing.T) {
+	c := dealCommon(`vkey=abc`)
+	if c.Tp != "tcp" {
+		t.Fatalf("unexpected default tp: %s", c.Tp)
+	}
+	if !c.AutoReconnection {
+		t.Fatalf("unexpected default auto_reconnection: %v", c.AutoReconnection)
+	}
+	if c.Client == nil || c.Client.Cnf == nil {
+		t.Fatalf("client defaults are not initialized")
 	}
 }
 
@@ -65,5 +108,13 @@ func TestGetTitleContent(t *testing.T) {
 	s := "[common]"
 	if getTitleContent(s) != "common" {
 		t.Fail()
+	}
+}
+
+func TestStripCommentLines(t *testing.T) {
+	content := "a=1\n#comment\n  #comment2\nb=2\n"
+	cleaned := stripCommentLines(content)
+	if cleaned != "a=1\nb=2\n" {
+		t.Fatalf("unexpected cleaned config: %q", cleaned)
 	}
 }


### PR DESCRIPTION
### Motivation
- Fix brittle and failing unit tests in `lib/config` that no longer matched current parsing keys and behaviors.
- Improve coverage for parsing defaults and comment-stripping to prevent regressions in configuration preprocessing.

### Description
- Update `TestReg` to assert the expected number of titles and return clear errors instead of only printing output.
- Replace fragile full-struct comparison in `TestDealCommon` with explicit assertions using current keys like `server_addr` and `conn_type` and additional fields for auth/limits.
- Add `TestDealCommon_Defaults` to validate default values for `tp`, `auto_reconnection`, and `Client/Cnf` initialization.
- Add `TestStripCommentLines` to verify that comment lines are correctly removed by `stripCommentLines`.

### Testing
- Ran `go test ./lib/config` and it passed successfully.
- Ran `go test ./lib/...` and observed unrelated failures in other packages due to missing external tools (`docker`, `tc`) and port conflicts, which are not affected by this change.

------
