### PR TITLE
Optimize UDP datagram parsing to reduce transient allocations

### DIFF
--- a/lib/common/netpackager.go
+++ b/lib/common/netpackager.go
@@ -175,29 +175,31 @@ func ReadUDPDatagram(r io.Reader) (*UDPDatagram, error) {
 	}
 
 	dlen := int(header.Rsv)
-	if dlen == 0 {
-		// standard SOCKS5 UDP datagram: read the rest (we assume r is bounded, e.g., framed)
-		extra, err := io.ReadAll(r)
-		if err != nil {
+	if hlen > n {
+		if _, err := io.ReadFull(r, b[n:hlen]); err != nil {
 			return nil, err
 		}
-		copy(b[n:], extra)
-		n += len(extra) // total length
-		dlen = n - hlen // payload length
-	} else {
-		// extended feature: RSV carries data length
-		if _, err := io.ReadFull(r, b[n:hlen+dlen]); err != nil {
-			return nil, err
-		}
-		n = hlen + dlen
+		n = hlen
 	}
 
 	header.Addr = new(Addr)
 	if err := header.Addr.Decode(b[3:hlen]); err != nil {
 		return nil, err
 	}
-	data := make([]byte, dlen)
-	copy(data, b[hlen:n])
+	var data []byte
+	if dlen == 0 {
+		// standard SOCKS5 UDP datagram: read the rest (we assume r is bounded, e.g., framed)
+		data, err = io.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// extended feature: RSV carries data length
+		data = make([]byte, dlen)
+		if _, err := io.ReadFull(r, data); err != nil {
+			return nil, err
+		}
+	}
 	d := &UDPDatagram{
 		Header: header,
 		Data:   data,


### PR DESCRIPTION
### Motivation
- Reduce peak memory usage when parsing SOCKS5 UDP datagrams by removing an extra temporary allocation and copy in the common path while keeping performance and behavior unchanged.

### Description
- Refactored `ReadUDPDatagram` in `lib/common/netpackager.go` to read any remaining header bytes first and decode the address before handling payload.
- For standard SOCKS5 datagrams (`RSV == 0`) the code now returns `data` read directly instead of allocating an intermediate buffer and copying into another slice.
- For extended mode (`RSV > 0`) the payload is read directly into a pre-sized `data` slice to avoid an extra copy.
- Change affects only allocation/reading pattern in `lib/common/netpackager.go` and preserves packet semantics.

### Testing
- Ran `go test ./lib/common` which passed.
- Ran `go test ./lib/conn` which passed in this environment.
- Attempted `go test ./lib/mux` but it failed due to missing external system tools (`docker`, `tc`) required by that package's integration tests; failures are environment-related and not caused by this change.

------
