### PR TITLE
Optimize conn parsing helpers to reduce transient allocations

### DIFF
--- a/lib/conn/conn.go
+++ b/lib/conn/conn.go
@@ -25,6 +25,7 @@ import (
 )
 
 var LocalTCPAddr = &net.TCPAddr{IP: net.ParseIP("127.0.0.1")}
+var requestEndBytes = []byte("\r\n\r\n")
 
 type Conn struct {
 	Conn       net.Conn
@@ -71,7 +72,7 @@ func (s *Conn) readRequest(buf []byte) (n int, err error) {
 		if n < 4 {
 			continue
 		}
-		if string(buf[n-4:n]) == "\r\n\r\n" {
+		if bytes.Equal(buf[n-4:n], requestEndBytes) {
 			return
 		}
 		// buf is full, can't contain the request
@@ -162,8 +163,9 @@ func (s *Conn) WriteLenContent(buf []byte) (err error) {
 
 // ReadFlag read flag
 func (s *Conn) ReadFlag() (string, error) {
-	buf := make([]byte, 4)
-	return string(buf), binary.Read(s, binary.LittleEndian, &buf)
+	var buf [4]byte
+	_, err := io.ReadFull(s, buf[:])
+	return string(buf[:]), err
 }
 
 // SetAlive set alive
@@ -214,8 +216,8 @@ func (s *Conn) GetLinkInfo() (lk *Link, err error) {
 
 // SendHealthInfo send info for link
 func (s *Conn) SendHealthInfo(info, status string) (int, error) {
-	raw := bytes.NewBuffer([]byte{})
-	common.BinaryWrite(raw, info, status)
+	var raw bytes.Buffer
+	common.BinaryWrite(&raw, info, status)
 	return s.Write(raw.Bytes())
 }
 


### PR DESCRIPTION
### Motivation

- Reduce heap allocations and memory churn in connection hot paths without changing behavior or performance.
- Eliminate repeated small temporary allocations created during HTTP request parsing and flag/health serialization.
- Improve memory efficiency in frequently-called helpers to lower GC pressure under load.

### Description

- Added a shared `requestEndBytes` sentinel and switched the HTTP request terminator check to `bytes.Equal` to avoid creating temporary strings in `readRequest` in `lib/conn/conn.go`.
- Replaced `make([]byte, 4)` with a fixed-size stack array `var buf [4]byte` and `io.ReadFull` in `ReadFlag` to avoid small heap allocations.
- Replaced `bytes.NewBuffer([]byte{})` with a stack `var raw bytes.Buffer` and adjusted `common.BinaryWrite` call to write into `&raw` in `SendHealthInfo` to remove an unnecessary buffer allocation.

### Testing

- Ran `go test ./lib/conn ./lib/common` and both packages passed (`ok`).

------
