### PR TITLE
Reduce logger in-memory buffer retention after flush

### DIFF
--- a/lib/logs/logger.go
+++ b/lib/logs/logger.go
@@ -23,6 +23,7 @@ var (
 )
 
 const defaultBufSize = 64 * 1024 // 64KB
+const maxRetainedBufferMultiple = 4
 
 type BufferWriter struct {
 	mu  sync.Mutex
@@ -59,7 +60,15 @@ func (w *BufferWriter) GetAndClear() string {
 	defer w.mu.Unlock()
 	s := w.buf.String()
 	w.buf.Reset()
+	w.shrinkIfNeeded()
 	return s
+}
+
+func (w *BufferWriter) shrinkIfNeeded() {
+	if w.buf.Cap() <= w.cap*maxRetainedBufferMultiple {
+		return
+	}
+	w.buf = bytes.NewBuffer(make([]byte, 0, w.cap))
 }
 
 // EnableInMemoryBuffer activates an in-memory circular buffer of given capacity


### PR DESCRIPTION
### Motivation
- Avoid holding oversized backing arrays in the in-memory log buffer after temporary log spikes so steady-state memory usage is reduced without touching hot write paths.

### Description
- Added `maxRetainedBufferMultiple = 4` to control when the buffer backing array should be compacted.
- Call `shrinkIfNeeded()` from `GetAndClear()` in `lib/logs/logger.go` to reallocate the internal `bytes.Buffer` to the configured capacity when the current capacity is significantly larger than desired.
- Implemented `shrinkIfNeeded()` which replaces `w.buf` with a new `bytes.Buffer` of size `w.cap` when needed, leaving the `Write` path unchanged.

### Testing
- Ran `gofmt -w lib/logs/logger.go` successfully.
- Ran `go test ./lib/logs ./lib/common` with results: `lib/logs` has no test files and `lib/common` tests passed (`ok`).

------
