### PR TITLE
Strengthen tests: config parsing assertions, integration guard for mux tests, and pmux listener checks

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"regexp"
 	"testing"
 )
@@ -43,21 +42,65 @@ p=2
 `
 	re, err := regexp.Compile(`\[.+?\]`)
 	if err != nil {
-		t.Fail()
+		t.Fatalf("compile regexp failed: %v", err)
 	}
-	log.Println(re.FindAllString(content, -1))
+	all := re.FindAllString(content, -1)
+	if len(all) != 5 {
+		t.Fatalf("unexpected title count: %d", len(all))
+	}
 }
 
 func TestDealCommon(t *testing.T) {
-	s := `server=127.0.0.1:8284
-tp=tcp
-vkey=123`
-	f := new(CommonConfig)
-	f.Server = "127.0.0.1:8284"
-	f.Tp = "tcp"
-	f.VKey = "123"
-	if c := dealCommon(s); *c != *f {
-		t.Fail()
+	s := `server_addr=127.0.0.1:8284
+conn_type=kcp
+vkey=123
+auto_reconnection=false
+basic_username=admin
+basic_password=pass
+compress=false
+crypt=false
+web_username=user
+web_password=web-pass
+rate_limit=1024
+flow_limit=2048
+max_conn=12
+disconnect_timeout=30
+tls_enable=true`
+
+	c := dealCommon(s)
+	if c.Server != "127.0.0.1:8284" || c.Tp != "kcp" || c.VKey != "123" {
+		t.Fatalf("basic common fields parse failed: %+v", c)
+	}
+	if c.AutoReconnection {
+		t.Fatalf("auto_reconnection should be false")
+	}
+	if c.Client == nil || c.Client.Cnf == nil {
+		t.Fatalf("client or client config not initialized")
+	}
+	if c.Client.Cnf.U != "admin" || c.Client.Cnf.P != "pass" {
+		t.Fatalf("basic auth parse failed: %+v", c.Client.Cnf)
+	}
+	if c.Client.WebUserName != "user" || c.Client.WebPassword != "web-pass" {
+		t.Fatalf("web auth parse failed: %+v", c.Client)
+	}
+	if c.Client.RateLimit != 1024 || c.Client.Flow.FlowLimit != 2048 || c.Client.MaxConn != 12 {
+		t.Fatalf("limit fields parse failed: %+v", c.Client)
+	}
+	if c.DisconnectTime != 30 || !c.TlsEnable {
+		t.Fatalf("disconnect or tls parse failed: %+v", c)
+	}
+}
+
+func TestDealCommon_Defaults(t *testing.T) {
+	c := dealCommon(`vkey=abc`)
+	if c.Tp != "tcp" {
+		t.Fatalf("unexpected default tp: %s", c.Tp)
+	}
+	if !c.AutoReconnection {
+		t.Fatalf("unexpected default auto_reconnection: %v", c.AutoReconnection)
+	}
+	if c.Client == nil || c.Client.Cnf == nil {
+		t.Fatalf("client defaults are not initialized")
 	}
 }
 
@@ -65,5 +108,13 @@ func TestGetTitleContent(t *testing.T) {
 	s := "[common]"
 	if getTitleContent(s) != "common" {
 		t.Fail()
+	}
+}
+
+func TestStripCommentLines(t *testing.T) {
+	content := "a=1\n#comment\n  #comment2\nb=2\n"
+	cleaned := stripCommentLines(content)
+	if cleaned != "a=1\nb=2\n" {
+		t.Fatalf("unexpected cleaned config: %q", cleaned)
 	}
 }

--- a/lib/mux/mux_test.go
+++ b/lib/mux/mux_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httputil"
 	_ "net/http/pprof"
 	"os"
+	"os/exec"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -38,7 +39,20 @@ var network = "172.18.0.0/16"
 var fileSavePath = "/usr/src/myapp/"
 var dataSize = 1024 * 1024 * 100
 
+func requireIntegrationEnv(t *testing.T) {
+	t.Helper()
+	if os.Getenv("NPS_RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("integration test skipped: set NPS_RUN_INTEGRATION_TESTS=1 to enable")
+	}
+	for _, tool := range []string{"docker", "tc"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("integration test skipped: missing required tool %q", tool)
+		}
+	}
+}
+
 func TestMux(t *testing.T) {
+	requireIntegrationEnv(t)
 	pwd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -98,6 +112,7 @@ func appendResult(values []float64, outfile string) error {
 }
 
 func TestServer(t *testing.T) {
+	requireIntegrationEnv(t)
 	tc, err := NewTrafficControl(serverIp)
 	if err != nil {
 		t.Fatal(err, tc)
@@ -162,6 +177,7 @@ func TestServer(t *testing.T) {
 	}
 }
 func TestClient(t *testing.T) {
+	requireIntegrationEnv(t)
 	tc, err := NewTrafficControl(clientIp)
 	if err != nil {
 		t.Fatal(err, tc)
@@ -214,6 +230,7 @@ func TestClient(t *testing.T) {
 	}
 }
 func TestApp(t *testing.T) {
+	requireIntegrationEnv(t)
 	tc, err := NewTrafficControl(appIp)
 	if err != nil {
 		t.Fatal(err, tc)
@@ -281,6 +298,7 @@ func TestApp(t *testing.T) {
 	}
 }
 func TestUser(t *testing.T) {
+	requireIntegrationEnv(t)
 	tc, err := NewTrafficControl(userIp)
 	if err != nil {
 		t.Fatal(err, tc)
@@ -338,6 +356,7 @@ func TestUser(t *testing.T) {
 	}
 }
 func TestNewMux2(t *testing.T) {
+	requireIntegrationEnv(t)
 	tc, err := NewTrafficControl("")
 	if err != nil {
 		t.Fatal(err)
@@ -389,6 +408,7 @@ func TestNewMux2(t *testing.T) {
 	log.Println(err)
 }
 func TestNewMux(t *testing.T) {
+	t.Skip("manual long-running test; not suitable for automated unit test runs")
 	go func() {
 		_ = http.ListenAndServe("0.0.0.0:8889", nil)
 	}()
@@ -619,6 +639,7 @@ func TestDQueue(t *testing.T) {
 }
 
 func TestChain(t *testing.T) {
+	t.Skip("stress/manual test; not suitable for automated unit test runs")
 	go func() {
 		log.Println(http.ListenAndServe("0.0.0.0:8889", nil))
 	}()

--- a/lib/pmux/pmux_test.go
+++ b/lib/pmux/pmux_test.go
@@ -1,38 +1,52 @@
 package pmux
 
 import (
+	"net"
 	"testing"
-	"time"
 
 	"github.com/djylb/nps/lib/logs"
 )
 
-func TestPortMux_Close(t *testing.T) {
+func getFreePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen free port failed: %v", err)
+	}
+	defer l.Close()
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("unexpected addr type: %T", l.Addr())
+	}
+	return addr.Port
+}
+
+func TestPortMux_ListenersAndClose(t *testing.T) {
 	logs.Init("stdout", "trace", "", 0, 0, 0, false, true)
 
-	pMux := NewPortMux(8888, "Ds", "Cs")
-	go func() {
-		if pMux.Start() != nil {
-			logs.Warn("Error")
-		}
-	}()
-	time.Sleep(time.Second * 3)
-	go func() {
-		l := pMux.GetHttpListener()
-		conn, err := l.Accept()
-		logs.Warn("%v %v", conn, err)
-	}()
-	go func() {
-		l := pMux.GetHttpListener()
-		conn, err := l.Accept()
-		logs.Warn("%v %v", conn, err)
-	}()
-	go func() {
-		l := pMux.GetHttpListener()
-		conn, err := l.Accept()
-		logs.Warn("%v %v", conn, err)
-	}()
-	l := pMux.GetHttpListener()
-	conn, err := l.Accept()
-	logs.Warn("%v %v", conn, err)
+	port := getFreePort(t)
+	pMux := NewPortMux(port, "Ds", "Cs")
+	if pMux.Listener == nil {
+		t.Fatal("port mux listener not initialized")
+	}
+
+	if pMux.GetClientListener() == nil {
+		t.Fatal("client listener is nil")
+	}
+	if pMux.GetClientTlsListener() == nil {
+		t.Fatal("client tls listener is nil")
+	}
+	if pMux.GetHttpListener() == nil {
+		t.Fatal("http listener is nil")
+	}
+	if pMux.GetHttpsListener() == nil {
+		t.Fatal("https listener is nil")
+	}
+	if pMux.GetManagerListener() == nil {
+		t.Fatal("manager listener is nil")
+	}
+
+	if err := pMux.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
 }


### PR DESCRIPTION
### Motivation

- Make configuration parsing tests more robust and verify defaults and client-related fields. 
- Prevent long-running/integration mux tests from running accidentally in CI by gating them behind an explicit environment flag and tool checks. 
- Replace flaky/manual pmux test with deterministic checks that listeners are initialized and that `Close` works.

### Description

- Enhanced `lib/config/config_test.go` by tightening `TestReg` error handling, adding `TestDealCommon_Defaults` and `TestStripCommentLines`, and expanding `TestDealCommon` to assert many parsed fields including basic/web auth, limits, defaults, `DisconnectTime`, and `TlsEnable`.
- Added a `requireIntegrationEnv` helper to `lib/mux/mux_test.go` which skips integration tests unless `NPS_RUN_INTEGRATION_TESTS=1` and required tools (`docker`, `tc`) are available, and annotated multiple tests to call it before running; also imported `os/exec` for tool detection and skipped some long-running/manual tests with `t.Skip`.
- Reworked `lib/pmux/pmux_test.go` by adding `getFreePort` and replacing the previous manual test with `TestPortMux_ListenersAndClose` that validates listener getters (`GetClientListener`, `GetClientTlsListener`, `GetHttpListener`, `GetHttpsListener`, `GetManagerListener`) and calls `Close` to ensure proper shutdown.

### Testing

- Ran unit tests for the modified packages with integration tests skipped by default; `lib/config` unit tests passed. 
- `lib/pmux` unit tests passed validating listener initialization and `Close` behavior. 
- `lib/mux` integration tests are gated and are skipped unless `NPS_RUN_INTEGRATION_TESTS=1` and the `docker` and `tc` tools are present; when gated-enabled they run as integration tests (not executed by default in CI).

------
