### PR TITLE
Optimize pmux host header parsing allocations

### DIFF
--- a/lib/pmux/header_test.go
+++ b/lib/pmux/header_test.go
@@ -1,0 +1,26 @@
+package pmux
+
+import "testing"
+
+func TestParseHostHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		line []byte
+		want string
+		ok   bool
+	}{
+		{name: "standard", line: []byte("Host: example.com"), want: "example.com", ok: true},
+		{name: "lowercase", line: []byte("host: api.example.com:8080"), want: "api.example.com:8080", ok: true},
+		{name: "mixedcase and spaces", line: []byte("HoSt:   test.local  "), want: "test.local", ok: true},
+		{name: "not host", line: []byte("User-Agent: curl"), want: "", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseHostHeader(tt.line)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("parseHostHeader(%q) = (%q, %v), want (%q, %v)", tt.line, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/lib/pmux/pmux.go
+++ b/lib/pmux/pmux.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/djylb/nps/lib/common"
@@ -121,16 +120,12 @@ func (pMux *PortMux) process(conn net.Conn) {
 					break
 				}
 				buffer.Write(b)
-				buffer.Write([]byte("\r\n"))
-				if strings.Index(string(b), "Host:") == 0 || strings.Index(string(b), "host:") == 0 {
-					// Remove host and space effects
-					str := strings.Replace(string(b), "Host:", "", -1)
-					str = strings.Replace(str, "host:", "", -1)
-					str = strings.TrimSpace(str)
+				buffer.WriteString("\r\n")
+				if host, ok := parseHostHeader(b); ok {
 					// Determine whether it is the same as the manager domain name
-					if common.GetIpByAddr(str) == pMux.managerHost && pMux.managerConn != nil {
+					if common.GetIpByAddr(host) == pMux.managerHost && pMux.managerConn != nil {
 						ch = pMux.managerConn
-					} else if common.GetIpByAddr(str) == pMux.clientHost && pMux.clientWsConn != nil {
+					} else if common.GetIpByAddr(host) == pMux.clientHost && pMux.clientWsConn != nil {
 						ch = pMux.clientWsConn
 					} else if pMux.httpConn != nil {
 						ch = pMux.httpConn
@@ -207,6 +202,14 @@ func (pMux *PortMux) Close() error {
 	close(pMux.httpConn)
 	close(pMux.managerConn)
 	return pMux.Listener.Close()
+}
+
+func parseHostHeader(line []byte) (string, bool) {
+	const header = "host:"
+	if len(line) < len(header) || !bytes.EqualFold(line[:len(header)], []byte(header)) {
+		return "", false
+	}
+	return string(bytes.TrimSpace(line[len(header):])), true
 }
 
 func (pMux *PortMux) GetClientListener() net.Listener {


### PR DESCRIPTION
### Motivation
- Reduce temporary allocations and memory churn in the HTTP dispatch path by avoiding repeated `string` conversions and `strings.Replace` calls when parsing `Host` headers.
- Improve small-object allocations for header line writes by using `WriteString` instead of allocating a `[]byte` for `"\r\n"`.

### Description
- Replaced ad-hoc `string` and `strings.Replace` parsing with a byte-oriented helper `parseHostHeader([]byte) (string, bool)` that uses `bytes.EqualFold` and `bytes.TrimSpace` and converts to `string` only once when needed.
- Changed `buffer.Write([]byte("\r\n"))` to `buffer.WriteString("\r\n")` to avoid a small `[]byte` allocation per line.
- Removed the unused `strings` import in `lib/pmux/pmux.go` and added the new helper function `parseHostHeader` in the same file.
- Added unit tests in `lib/pmux/header_test.go` covering standard, lowercase, mixed-case with spaces, and non-Host header lines for `parseHostHeader` behavior.

### Testing
- Ran `go test ./lib/pmux -run TestParseHostHeader` and it passed successfully.
- Ran `go test ./lib/pmux -run TestDoesNotExist` as a compile/sanity check and it passed.
- Running the full `go test ./lib/pmux` currently fails due to an existing test (`TestPortMux_Close`) that attempts to bind port `8888` and triggers `os.Exit(0)` when the port is already in use; this is an existing test-suite issue unrelated to these changes.

------
