### PR TITLE
Fix in-memory log buffer overflow handling for oversized writes

### DIFF
--- a/lib/logs/logger.go
+++ b/lib/logs/logger.go
@@ -45,6 +45,12 @@ func (w *BufferWriter) Write(p []byte) (n int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	if len(p) >= w.cap {
+		w.buf.Reset()
+		w.buf.Write(p[len(p)-w.cap:])
+		return len(p), nil
+	}
+
 	if w.buf.Len()+len(p) > w.cap {
 		drop := w.buf.Len() + len(p) - w.cap
 		data := w.buf.Bytes()

--- a/lib/logs/logger_test.go
+++ b/lib/logs/logger_test.go
@@ -1,0 +1,38 @@
+package logs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBufferWriterWriteKeepsCapacityOnOverflow(t *testing.T) {
+	w := NewBufferWriter(16)
+
+	if _, err := w.Write([]byte("1234567890")); err != nil {
+		t.Fatalf("first write failed: %v", err)
+	}
+	if _, err := w.Write([]byte("abcdefghij")); err != nil {
+		t.Fatalf("second write failed: %v", err)
+	}
+
+	got := w.GetAndClear()
+	want := "567890abcdefghij"
+	if got != want {
+		t.Fatalf("unexpected buffer content, got %q want %q", got, want)
+	}
+}
+
+func TestBufferWriterWriteWithLargePayload(t *testing.T) {
+	w := NewBufferWriter(16)
+	large := strings.Repeat("x", 64)
+
+	if _, err := w.Write([]byte(large)); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	got := w.GetAndClear()
+	want := strings.Repeat("x", 16)
+	if got != want {
+		t.Fatalf("unexpected buffer content length=%d, want length=%d", len(got), len(want))
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent excessive memory use and out-of-range operations when a single log write is larger than the in-memory buffer capacity while keeping performance impact minimal. 
- Preserve existing circular-buffer semantics of keeping the most recent `cap` bytes.

### Description
- Add a fast-path in `BufferWriter.Write` to handle writes where `len(p) >= w.cap` by resetting the buffer and writing only the trailing `w.cap` bytes.  
- Keep the original rolling-drop logic for smaller writes so behavior remains consistent for typical cases.  
- Update `lib/logs/logger.go` to include the new fast-path and add unit tests in `lib/logs/logger_test.go` covering both overflow-by-accumulation and single oversized-write scenarios.  

### Testing
- Added `TestBufferWriterWriteKeepsCapacityOnOverflow` and `TestBufferWriterWriteWithLargePayload` in `lib/logs/logger_test.go`.  
- Ran `go test ./lib/logs`, which passed successfully.

------
