### PR TITLE
Optimize slice allocations in connection and DNS paths

### DIFF
--- a/lib/common/dns.go
+++ b/lib/common/dns.go
@@ -200,7 +200,7 @@ func resolveRecords(domain string, qtype uint16, server string, recurse bool) ([
 		return nil, err
 	}
 
-	var out []string
+	out := make([]string, 0, len(resp.Answer))
 	for _, ans := range resp.Answer {
 		switch rr := ans.(type) {
 		case *dns.A:

--- a/lib/mux/map.go
+++ b/lib/mux/map.go
@@ -42,8 +42,8 @@ func (s *ConnMap) Set(id int32, v *Conn) {
 
 func (s *ConnMap) Close() {
 	// first copy cMap, because conn close will call Delete to trigger dead lock
-	var copyMap []*Conn
 	s.RLock()
+	copyMap := make([]*Conn, 0, len(s.cMap))
 	for _, v := range s.cMap {
 		copyMap = append(copyMap, v)
 	}


### PR DESCRIPTION
### Motivation
- Reduce short-lived heap allocations in hot code paths to lower memory churn during high connection/DNS activity without changing behavior.

### Description
- Preallocate the temporary connection slice in `ConnMap.Close()` with `make([]*Conn, 0, len(s.cMap))` to avoid repeated growth when copying map values (file `lib/mux/map.go`).
- Preallocate the DNS result slice in `resolveRecords()` with `make([]string, 0, len(resp.Answer))` to avoid incremental reallocations while collecting answers (file `lib/common/dns.go`).

### Testing
- Ran `go test ./lib/common ./lib/mux` and both packages passed successfully.
- Ran `go test ./...` and the repository tests completed successfully (no failures).

------
