### PR TITLE
Optimize zap log adapter parsing to reduce allocations

### DIFF
--- a/lib/logs/logger.go
+++ b/lib/logs/logger.go
@@ -222,29 +222,43 @@ func SetLevel(levelStr string) {
 
 type zapAdapter struct{}
 
+var (
+	lineEndingBytes  = []byte(zapcore.DefaultLineEnding)
+	debugLevelBytes  = []byte("DEBUG")
+	infoLevelBytes   = []byte("INFO")
+	warnLevelBytes   = []byte("WARN")
+	warningBytes     = []byte("WARNING")
+	errorLevelBytes  = []byte("ERROR")
+	dpanicLevelBytes = []byte("DPANIC")
+	panicLevelBytes  = []byte("PANIC")
+	fatalLevelBytes  = []byte("FATAL")
+)
+
 func (zapAdapter) Write(p []byte) (n int, err error) {
-	s := strings.TrimSuffix(string(p), zapcore.DefaultLineEnding)
-	parts := strings.SplitN(s, "\t", 2)
-	levelStr, msg := "INFO", s
-	if len(parts) == 2 {
-		levelStr = parts[0]
-		msg = parts[1]
+	line := bytes.TrimSuffix(p, lineEndingBytes)
+	level := infoLevelBytes
+	msg := line
+	if i := bytes.IndexByte(line, '\t'); i >= 0 {
+		level = line[:i]
+		msg = line[i+1:]
 	}
-	switch levelStr {
-	case "DEBUG":
-		Logger.Debug().Msg(msg)
-	case "INFO":
-		Logger.Info().Msg(msg)
-	case "WARN", "WARNING":
-		Logger.Warn().Msg(msg)
-	case "ERROR":
-		Logger.Error().Msg(msg)
-	case "DPANIC", "PANIC":
-		Logger.Panic().Msg(msg)
-	case "FATAL":
-		Logger.Fatal().Msg(msg)
+
+	msgStr := string(msg)
+	switch {
+	case bytes.Equal(level, debugLevelBytes):
+		Logger.Debug().Msg(msgStr)
+	case bytes.Equal(level, infoLevelBytes):
+		Logger.Info().Msg(msgStr)
+	case bytes.Equal(level, warnLevelBytes), bytes.Equal(level, warningBytes):
+		Logger.Warn().Msg(msgStr)
+	case bytes.Equal(level, errorLevelBytes):
+		Logger.Error().Msg(msgStr)
+	case bytes.Equal(level, dpanicLevelBytes), bytes.Equal(level, panicLevelBytes):
+		Logger.Panic().Msg(msgStr)
+	case bytes.Equal(level, fatalLevelBytes):
+		Logger.Fatal().Msg(msgStr)
 	default:
-		Logger.Info().Msg(msg)
+		Logger.Info().Msg(msgStr)
 	}
 	return len(p), nil
 }


### PR DESCRIPTION
### Motivation
- Reduce per-log-call memory allocations in the hot logging path to lower overall memory churn without changing behavior.
- Avoid repeated temporary `string` conversions and `SplitN`/`TrimSuffix` allocations when adapting zap output.
- Keep existing log level semantics and output behavior intact while using lower-allocation parsing.

### Description
- Reworked `zapAdapter.Write` in `lib/logs/logger.go` to parse the incoming `[]byte` directly instead of converting to `string` and using `strings.SplitN`/`TrimSuffix`.
- Introduced reusable byte-slice constants for the line ending and level labels (e.g. `lineEndingBytes`, `debugLevelBytes`, `infoLevelBytes`) to avoid recreating them per call.
- Only convert the final message portion to `string` once (`msgStr`) before forwarding to the existing `Logger` methods, preserving all level mappings (`DEBUG`, `INFO`, `WARN`, `WARNING`, `ERROR`, `DPANIC`, `PANIC`, `FATAL`).

### Testing
- Formatted the file with `gofmt -w lib/logs/logger.go` and ran the full test suite with `go test ./...` which completed successfully.
- Verified that packages depending on `lib/logs` build and tests for related packages passed. 
- No test failures were introduced by this change.

------
