### PR TITLE
mux: guard window buffer pool against abnormal slices

### DIFF
--- a/lib/mux/pool.go
+++ b/lib/mux/pool.go
@@ -43,6 +43,9 @@ func (Self *windowBufferPool) Get() (buf []byte) {
 
 func (Self *windowBufferPool) Put(x []byte) {
 	//trace(x, "put")
+	if cap(x) != poolSizeWindowBuffer {
+		return
+	}
 	Self.pool.Put(x[:poolSizeWindowBuffer]) // make buf to full
 }
 

--- a/lib/mux/pool_test.go
+++ b/lib/mux/pool_test.go
@@ -1,0 +1,33 @@
+package mux
+
+import "testing"
+
+func TestWindowBufferPoolPutRejectsUnexpectedCapacity(t *testing.T) {
+	p := newWindowBufferPool()
+
+	assertNoPanic := func(name string, fn func()) {
+		t.Helper()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked: %v", name, r)
+			}
+		}()
+		fn()
+	}
+
+	assertNoPanic("small buffer", func() {
+		p.Put(make([]byte, poolSizeWindowBuffer/2))
+	})
+
+	assertNoPanic("large buffer", func() {
+		p.Put(make([]byte, poolSizeWindowBuffer*2))
+	})
+
+	buf := p.Get()
+	if len(buf) != poolSizeWindowBuffer {
+		t.Fatalf("unexpected len: got %d want %d", len(buf), poolSizeWindowBuffer)
+	}
+	if cap(buf) != poolSizeWindowBuffer {
+		t.Fatalf("unexpected cap: got %d want %d", cap(buf), poolSizeWindowBuffer)
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent accidental retention of oversized slices in the `windowBufferPool` which can increase memory pressure.
- Avoid panics or incorrect behavior caused by undersized slices being passed to the pool when re-slicing to the fixed buffer size.
- Keep performance impact minimal by using a single `cap` check before returning buffers to the pool.

### Description
- Add a capacity guard in `windowBufferPool.Put` so only slices whose `cap` equals `poolSizeWindowBuffer` are returned to the `sync.Pool` in `lib/mux/pool.go`.
- Preserve existing `Get` behavior which returns a correctly sized slice of length `poolSizeWindowBuffer`.
- Add a focused unit test `TestWindowBufferPoolPutRejectsUnexpectedCapacity` in `lib/mux/pool_test.go` that ensures putting undersized and oversized slices does not panic and that `Get` still returns a buffer with the expected length and capacity.

### Testing
- Ran the focused test with `go test ./lib/mux -run TestWindowBufferPoolPutRejectsUnexpectedCapacity -count=1` and it passed.
- Ran the package tests with `go test ./lib/mux -count=1` and they passed.

------
