### PR TITLE
test: add missing unit tests for clearClientStatus

### DIFF
--- a/web/controllers/client_test.go
+++ b/web/controllers/client_test.go
@@ -3,6 +3,10 @@ package controllers
 import (
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/djylb/nps/lib/file"
+	"github.com/djylb/nps/lib/rate"
 )
 
 func TestRemoveRepeatedElement(t *testing.T) {
@@ -26,4 +30,96 @@ func TestRemoveRepeatedElement(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClearClientStatusBasicFields(t *testing.T) {
+	timeLimit := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name   string
+		mode   string
+		assert func(t *testing.T, c *file.Client)
+	}{
+		{
+			name: "clear flow limit",
+			mode: "flow_limit",
+			assert: func(t *testing.T, c *file.Client) {
+				if c.Flow.FlowLimit != 0 {
+					t.Fatalf("expected FlowLimit to be 0, got %d", c.Flow.FlowLimit)
+				}
+			},
+		},
+		{
+			name: "clear time limit",
+			mode: "time_limit",
+			assert: func(t *testing.T, c *file.Client) {
+				if !c.Flow.TimeLimit.IsZero() {
+					t.Fatalf("expected TimeLimit to be zero, got %v", c.Flow.TimeLimit)
+				}
+			},
+		},
+		{
+			name: "clear connection limit",
+			mode: "conn_limit",
+			assert: func(t *testing.T, c *file.Client) {
+				if c.MaxConn != 0 {
+					t.Fatalf("expected MaxConn to be 0, got %d", c.MaxConn)
+				}
+			},
+		},
+		{
+			name: "clear tunnel limit",
+			mode: "tunnel_limit",
+			assert: func(t *testing.T, c *file.Client) {
+				if c.MaxTunnelNum != 0 {
+					t.Fatalf("expected MaxTunnelNum to be 0, got %d", c.MaxTunnelNum)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &file.Client{
+				Flow:         &file.Flow{FlowLimit: 1024, TimeLimit: timeLimit},
+				Rate:         rate.NewRate(1024),
+				MaxConn:      10,
+				MaxTunnelNum: 20,
+			}
+
+			clearClientStatus(c, tt.mode)
+			tt.assert(t, c)
+		})
+	}
+}
+
+func TestClearClientStatusRateLimit(t *testing.T) {
+	t.Run("create rate when nil", func(t *testing.T) {
+		c := &file.Client{Flow: &file.Flow{}, RateLimit: 123, Rate: nil}
+
+		clearClientStatus(c, "rate_limit")
+
+		if c.RateLimit != 0 {
+			t.Fatalf("expected RateLimit to be 0, got %d", c.RateLimit)
+		}
+		if c.Rate == nil {
+			t.Fatal("expected Rate to be initialized")
+		}
+		if c.Rate.Limit() != 0 {
+			t.Fatalf("expected limiter limit to be 0, got %d", c.Rate.Limit())
+		}
+	})
+
+	t.Run("reset existing rate limit", func(t *testing.T) {
+		c := &file.Client{Flow: &file.Flow{}, RateLimit: 256, Rate: rate.NewRate(256 * 1024)}
+
+		clearClientStatus(c, "rate_limit")
+
+		if c.RateLimit != 0 {
+			t.Fatalf("expected RateLimit to be 0, got %d", c.RateLimit)
+		}
+		if c.Rate.Limit() != 0 {
+			t.Fatalf("expected limiter limit to be reset to 0, got %d", c.Rate.Limit())
+		}
+	})
 }


### PR DESCRIPTION
### Motivation
- Add unit tests to cover previously untested `clearClientStatus` behaviors so limits and rate limiter handling are validated.
- Ensure `rate_limit` branch behavior is verified when `Client.Rate` is nil and when a limiter already exists.

### Description
- Added table-driven tests in `web/controllers/client_test.go` to assert clearing of `flow_limit`, `time_limit`, `conn_limit`, and `tunnel_limit` fields. 
- Added focused tests for `rate_limit` that verify a `Rate` is created when nil and that an existing `Rate` has its limit reset to zero. 
- Imported `time`, `github.com/djylb/nps/lib/file`, and `github.com/djylb/nps/lib/rate` to support the new test cases.

### Testing
- Ran `go test ./web/controllers` which succeeded. 
- Ran `go test ./...` which succeeded (all packages completed or reported no test files).

------
