### PR TITLE
test: add missing unit tests for lib/logs

### DIFF
--- a/lib/logs/logger_test.go
+++ b/lib/logs/logger_test.go
@@ -3,7 +3,23 @@ package logs
 import (
 	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
 )
+
+func resetTestLoggerState() {
+	bufferWriter = nil
+	Logger = zerolog.Nop()
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+}
+
+func TestNewBufferWriterUsesDefaultCapacityForInvalidInput(t *testing.T) {
+	w := NewBufferWriter(0)
+
+	if w.cap != defaultBufSize {
+		t.Fatalf("unexpected capacity, got %d want %d", w.cap, defaultBufSize)
+	}
+}
 
 func TestBufferWriterWriteKeepsCapacityOnOverflow(t *testing.T) {
 	w := NewBufferWriter(16)
@@ -34,5 +50,89 @@ func TestBufferWriterWriteWithLargePayload(t *testing.T) {
 	want := strings.Repeat("x", 16)
 	if got != want {
 		t.Fatalf("unexpected buffer content length=%d, want length=%d", len(got), len(want))
+	}
+}
+
+func TestBufferWriterGetAndClearShrinksOversizedBuffer(t *testing.T) {
+	w := NewBufferWriter(16)
+	large := strings.Repeat("x", 128)
+
+	if _, err := w.Write([]byte(large)); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	_ = w.GetAndClear()
+	if gotCap := w.buf.Cap(); gotCap > 16*maxRetainedBufferMultiple {
+		t.Fatalf("buffer should be shrunk, got cap=%d", gotCap)
+	}
+}
+
+func TestEnableInMemoryBufferAndGetBufferedLogs(t *testing.T) {
+	resetTestLoggerState()
+	t.Cleanup(resetTestLoggerState)
+
+	EnableInMemoryBuffer(32)
+	if bufferWriter == nil {
+		t.Fatalf("buffer writer should be initialized")
+	}
+
+	Init("off", "info", "", 1, 1, 1, false, false)
+	Info("hello")
+
+	firstRead := GetBufferedLogs()
+	if !strings.Contains(firstRead, "hello") {
+		t.Fatalf("expected buffered logs to contain message, got %q", firstRead)
+	}
+
+	secondRead := GetBufferedLogs()
+	if secondRead != "" {
+		t.Fatalf("expected second read to be empty, got %q", secondRead)
+	}
+}
+
+func TestSetLevelIgnoresInvalidLevel(t *testing.T) {
+	resetTestLoggerState()
+	t.Cleanup(resetTestLoggerState)
+
+	SetLevel("debug")
+	if got := zerolog.GlobalLevel(); got != zerolog.DebugLevel {
+		t.Fatalf("unexpected level after valid update, got %s", got)
+	}
+
+	SetLevel("invalid-level")
+	if got := zerolog.GlobalLevel(); got != zerolog.DebugLevel {
+		t.Fatalf("invalid level should not update global level, got %s", got)
+	}
+}
+
+func TestZapAdapterWriteRoutesLevels(t *testing.T) {
+	resetTestLoggerState()
+	t.Cleanup(resetTestLoggerState)
+
+	EnableInMemoryBuffer(1024)
+	Init("off", "debug", "", 1, 1, 1, false, false)
+
+	adapter := zapAdapter{}
+	cases := []string{
+		"DEBUG\tdebug msg\n",
+		"INFO\tinfo msg\n",
+		"WARN\twarn msg\n",
+		"WARNING\twarning msg\n",
+		"ERROR\terror msg\n",
+		"UNKNOWN\tfallback msg\n",
+		"message without tab\n",
+	}
+
+	for _, c := range cases {
+		if _, err := adapter.Write([]byte(c)); err != nil {
+			t.Fatalf("write failed for %q: %v", c, err)
+		}
+	}
+
+	logs := GetBufferedLogs()
+	for _, msg := range []string{"debug msg", "info msg", "warn msg", "warning msg", "error msg", "fallback msg", "message without tab"} {
+		if !strings.Contains(logs, msg) {
+			t.Fatalf("expected logs to include %q, got %q", msg, logs)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Fill missing unit tests for the logging package to improve coverage and prevent global test-state interference.

### Description
- Add `resetTestLoggerState` helper to reset `bufferWriter`, `Logger`, and global `zerolog` level between tests.
- Add test `TestNewBufferWriterUsesDefaultCapacityForInvalidInput` to validate `NewBufferWriter(0)` falls back to `defaultBufSize`.
- Add tests `TestBufferWriterGetAndClearShrinksOversizedBuffer`, `TestEnableInMemoryBufferAndGetBufferedLogs`, and `TestSetLevelIgnoresInvalidLevel` to cover buffer shrinking, in-memory buffering behavior, and `SetLevel` handling of invalid input.
- Add `TestZapAdapterWriteRoutesLevels` to verify `zapAdapter.Write` routes messages for DEBUG/INFO/WARN/WARNING/ERROR/unknown levels and lines without a tab to the in-memory buffer.

### Testing
- Ran `go test ./lib/logs` and it passed successfully.
- Ran `go test ./...` and the test suite completed without failures.

------
