### PR TITLE
test: add ProxyACL parsing and matching unit tests

### DIFF
--- a/lib/common/proxyacl_test.go
+++ b/lib/common/proxyacl_test.go
@@ -1,0 +1,84 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProxyACLEntries(t *testing.T) {
+	raw := "\n # comment\n;comment2\nEXAMPLE.com\n10.0.0.0/8\n[2001:db8::1]:443\n中文：8080\n"
+	got := ParseProxyACLEntries(raw)
+	want := []string{"example.com", "10.0.0.0/8", "[2001:db8::1]:443", "中文:8080"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseProxyACLEntries() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseProxyACLBuildsMatchers(t *testing.T) {
+	acl := ParseProxyACL("\n127.0.0.1\n10.0.0.0/8\nEXAMPLE.com\n*.sub.example.com\n*example.com\ninvalid/path\n")
+
+	if !acl.Enabled() {
+		t.Fatalf("expected acl to be enabled")
+	}
+	if _, ok := acl.ExactIPs["127.0.0.1"]; !ok {
+		t.Fatalf("expected exact ip matcher to contain 127.0.0.1")
+	}
+	if len(acl.CIDRs) != 1 {
+		t.Fatalf("expected 1 CIDR matcher, got %d", len(acl.CIDRs))
+	}
+	if _, ok := acl.Hostnames["example.com"]; !ok {
+		t.Fatalf("expected hostname matcher to contain example.com")
+	}
+
+	wantWildcards := []string{".sub.example.com", "example.com"}
+	if !reflect.DeepEqual(acl.WildcardSuffixes, wantWildcards) {
+		t.Fatalf("WildcardSuffixes = %#v, want %#v", acl.WildcardSuffixes, wantWildcards)
+	}
+}
+
+func TestProxyACLAllows(t *testing.T) {
+	acl := ParseProxyACL("\n127.0.0.1\n10.0.0.0/8\nexample.com\n*.a.com\n*a.net\n")
+
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{name: "exact ipv4", addr: "127.0.0.1:80", want: true},
+		{name: "cidr ipv4", addr: "10.11.12.13:443", want: true},
+		{name: "exact hostname", addr: "EXAMPLE.COM:8443", want: true},
+		{name: "subdomain wildcard only", addr: "x.a.com:443", want: true},
+		{name: "root denied for subdomain-only wildcard", addr: "a.com:443", want: false},
+		{name: "root allowed for include-root wildcard", addr: "a.net:443", want: true},
+		{name: "subdomain allowed for include-root wildcard", addr: "b.a.net:443", want: true},
+		{name: "boundary check denied", addr: "xxa.net:443", want: false},
+		{name: "not in acl", addr: "deny.example.org:443", want: false},
+		{name: "invalid empty", addr: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := acl.Allows(tc.addr); got != tc.want {
+				t.Fatalf("Allows(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProxyACLDisabledAndNil(t *testing.T) {
+	var nilACL *ProxyACL
+	if nilACL.Enabled() {
+		t.Fatalf("nil acl should be disabled")
+	}
+	if nilACL.Allows("127.0.0.1:80") {
+		t.Fatalf("nil acl should not allow any addr")
+	}
+
+	empty := ParseProxyACL("\n #only comments\n")
+	if empty.Enabled() {
+		t.Fatalf("empty acl should be disabled")
+	}
+	if empty.Allows("example.com:443") {
+		t.Fatalf("empty acl should not allow any addr")
+	}
+}


### PR DESCRIPTION
### Motivation
- Add coverage for previously missing unit tests around proxy ACL parsing and matching to ensure normalization, wildcard semantics, and matcher construction behave as expected.
- Verify edge cases such as full-width colon replacement, comment/whitespace handling, subdomain-only vs include-root wildcard behavior, and nil/empty ACL handling.

### Description
- Add `lib/common/proxyacl_test.go` containing focused tests for `ParseProxyACLEntries` that cover comment filtering, lowercasing, and full-width colon normalization.
- Add tests for `ParseProxyACL` to validate construction of `ExactIPs`, `CIDRs`, `Hostnames`, and `WildcardSuffixes` including ordering semantics.
- Add a table-driven test for `ProxyACL.Allows` to exercise exact IP, CIDR, hostname matching, wildcard boundary conditions, and invalid/empty addresses.
- Add tests that confirm `Enabled` and `Allows` behave correctly for nil and empty ACL instances.

### Testing
- Ran `go test ./lib/common` and the package tests passed successfully.
- Ran `go test ./...` to validate the repository test suite and the run completed successfully.

------
