### PR TITLE
Optimize in-memory logging buffer performance and memory usage

### DIFF
--- a/lib/logs/logger.go
+++ b/lib/logs/logger.go
@@ -23,12 +23,13 @@ var (
 )
 
 const defaultBufSize = 64 * 1024 // 64KB
-const maxRetainedBufferMultiple = 4
 
 type BufferWriter struct {
-	mu  sync.Mutex
-	buf *bytes.Buffer
-	cap int
+	mu    sync.Mutex
+	buf   []byte
+	cap   int
+	start int
+	size  int
 }
 
 func NewBufferWriter(capacity int) *BufferWriter {
@@ -36,7 +37,7 @@ func NewBufferWriter(capacity int) *BufferWriter {
 		capacity = defaultBufSize
 	}
 	return &BufferWriter{
-		buf: bytes.NewBuffer(make([]byte, 0, capacity)),
+		buf: make([]byte, capacity),
 		cap: capacity,
 	}
 }
@@ -46,35 +47,47 @@ func (w *BufferWriter) Write(p []byte) (n int, err error) {
 	defer w.mu.Unlock()
 
 	if len(p) >= w.cap {
-		w.buf.Reset()
-		w.buf.Write(p[len(p)-w.cap:])
+		copy(w.buf, p[len(p)-w.cap:])
+		w.start = 0
+		w.size = w.cap
 		return len(p), nil
 	}
 
-	if w.buf.Len()+len(p) > w.cap {
-		drop := w.buf.Len() + len(p) - w.cap
-		data := w.buf.Bytes()
-		w.buf.Reset()
-		w.buf.Write(data[drop:])
+	if w.size+len(p) > w.cap {
+		drop := w.size + len(p) - w.cap
+		w.start = (w.start + drop) % w.cap
+		w.size -= drop
 	}
-	w.buf.Write(p)
+
+	writePos := (w.start + w.size) % w.cap
+	written := copy(w.buf[writePos:], p)
+	if written < len(p) {
+		copy(w.buf, p[written:])
+	}
+	w.size += len(p)
 	return len(p), nil
 }
 
 func (w *BufferWriter) GetAndClear() string {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	s := w.buf.String()
-	w.buf.Reset()
-	w.shrinkIfNeeded()
-	return s
-}
-
-func (w *BufferWriter) shrinkIfNeeded() {
-	if w.buf.Cap() <= w.cap*maxRetainedBufferMultiple {
-		return
+	if w.size == 0 {
+		return ""
 	}
-	w.buf = bytes.NewBuffer(make([]byte, 0, w.cap))
+
+	var s string
+	if w.start+w.size <= w.cap {
+		s = string(w.buf[w.start : w.start+w.size])
+	} else {
+		tmp := make([]byte, w.size)
+		n := copy(tmp, w.buf[w.start:])
+		copy(tmp[n:], w.buf[:w.size-n])
+		s = string(tmp)
+	}
+
+	w.start = 0
+	w.size = 0
+	return s
 }
 
 // EnableInMemoryBuffer activates an in-memory circular buffer of given capacity

--- a/lib/logs/logger_test.go
+++ b/lib/logs/logger_test.go
@@ -53,7 +53,7 @@ func TestBufferWriterWriteWithLargePayload(t *testing.T) {
 	}
 }
 
-func TestBufferWriterGetAndClearShrinksOversizedBuffer(t *testing.T) {
+func TestBufferWriterGetAndClearResetsState(t *testing.T) {
 	w := NewBufferWriter(16)
 	large := strings.Repeat("x", 128)
 
@@ -62,8 +62,11 @@ func TestBufferWriterGetAndClearShrinksOversizedBuffer(t *testing.T) {
 	}
 
 	_ = w.GetAndClear()
-	if gotCap := w.buf.Cap(); gotCap > 16*maxRetainedBufferMultiple {
-		t.Fatalf("buffer should be shrunk, got cap=%d", gotCap)
+	if w.start != 0 || w.size != 0 {
+		t.Fatalf("buffer state should be reset, start=%d size=%d", w.start, w.size)
+	}
+	if gotCap := len(w.buf); gotCap != 16 {
+		t.Fatalf("buffer capacity should remain fixed, got=%d", gotCap)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Reduce CPU and memory churn in the in-memory log buffer when logs are written at high throughput by avoiding repeated shifting and reallocation of a `bytes.Buffer` backing store.
- Keep only the most recent `capacity` bytes of logs with O(1) overwrite behavior to lower transient allocations and copies.

### Description

- Reworked `lib/logs.BufferWriter` to use a fixed-size ring buffer backed by a `[]byte` with `start` and `size` indexes instead of `bytes.Buffer` (change in `lib/logs/logger.go`).
- Implemented `Write` to directly copy data into the ring buffer with efficient handling for `len(p) >= cap` and wrap-around writes, and to drop only the necessary oldest bytes on overflow.
- Implemented `GetAndClear` to produce ordered output from the ring buffer and reset internal state (`start`/`size`) without dynamic shrink logic.
- Updated tests in `lib/logs/logger_test.go` to assert reset semantics and fixed buffer capacity for the new ring-buffer implementation.

### Testing

- Ran `go test ./lib/logs ./lib/common` and the tests passed successfully.
- Ran full test suite with `go test ./...` and all packages with tests completed successfully (other packages without tests reported as such).

------
