### PR TITLE
test: add missing unit tests for lib/crypt TOTP utilities

### DIFF
--- a/lib/crypt/otp_test.go
+++ b/lib/crypt/otp_test.go
@@ -1,0 +1,92 @@
+package crypt
+
+import (
+	"net/url"
+	"regexp"
+	"testing"
+)
+
+func TestGenerateTOTPSecret(t *testing.T) {
+	secret, err := GenerateTOTPSecret()
+	if err != nil {
+		t.Fatalf("GenerateTOTPSecret() error = %v", err)
+	}
+
+	if len(secret) != 16 {
+		t.Fatalf("GenerateTOTPSecret() secret length = %d, want 16", len(secret))
+	}
+
+	if matched := regexp.MustCompile(`^[A-Z2-7]+$`).MatchString(secret); !matched {
+		t.Fatalf("GenerateTOTPSecret() secret %q contains invalid base32 characters", secret)
+	}
+}
+
+func TestTOTPCodeRoundTrip(t *testing.T) {
+	secret, err := GenerateTOTPSecret()
+	if err != nil {
+		t.Fatalf("GenerateTOTPSecret() error = %v", err)
+	}
+
+	code, remaining, err := GetTOTPCode(secret)
+	if err != nil {
+		t.Fatalf("GetTOTPCode() error = %v", err)
+	}
+
+	if len(code) != TotpLen {
+		t.Fatalf("GetTOTPCode() code length = %d, want %d", len(code), TotpLen)
+	}
+	if remaining < 1 || remaining > 30 {
+		t.Fatalf("GetTOTPCode() remaining = %d, want in [1, 30]", remaining)
+	}
+
+	ok, err := ValidateTOTPCode(secret, code)
+	if err != nil {
+		t.Fatalf("ValidateTOTPCode() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ValidateTOTPCode() = false, want true for generated code")
+	}
+}
+
+func TestValidateTOTPCode_InvalidInput(t *testing.T) {
+	secret, err := GenerateTOTPSecret()
+	if err != nil {
+		t.Fatalf("GenerateTOTPSecret() error = %v", err)
+	}
+
+	if ok, err := ValidateTOTPCode("not-base32", "123456"); err == nil || ok {
+		t.Fatalf("ValidateTOTPCode(invalid secret) = (%v, %v), want (false, error)", ok, err)
+	}
+
+	if ok, err := ValidateTOTPCode(secret, "not-number"); err == nil || ok {
+		t.Fatalf("ValidateTOTPCode(invalid code) = (%v, %v), want (false, error)", ok, err)
+	}
+}
+
+func TestIsValidTOTPSecret(t *testing.T) {
+	secret, err := GenerateTOTPSecret()
+	if err != nil {
+		t.Fatalf("GenerateTOTPSecret() error = %v", err)
+	}
+	if !IsValidTOTPSecret(secret) {
+		t.Fatalf("IsValidTOTPSecret(%q) = false, want true", secret)
+	}
+	if IsValidTOTPSecret("%%%%") {
+		t.Fatal("IsValidTOTPSecret(%%%%) = true, want false")
+	}
+}
+
+func TestBuildTotpUri(t *testing.T) {
+	secret := "JBSWY3DPEHPK3PXP"
+	withIssuer := BuildTotpUri("nps team", "alice@example.com", secret)
+	wantWithIssuer := "otpauth://totp/" + url.QueryEscape("nps team:alice@example.com") + "?secret=" + secret + "&issuer=" + url.QueryEscape("nps team")
+	if withIssuer != wantWithIssuer {
+		t.Fatalf("BuildTotpUri(with issuer) = %q, want %q", withIssuer, wantWithIssuer)
+	}
+
+	withoutIssuer := BuildTotpUri("", "alice@example.com", secret)
+	wantWithoutIssuer := "otpauth://totp/" + url.QueryEscape("alice@example.com") + "?secret=" + secret
+	if withoutIssuer != wantWithoutIssuer {
+		t.Fatalf("BuildTotpUri(without issuer) = %q, want %q", withoutIssuer, wantWithoutIssuer)
+	}
+}


### PR DESCRIPTION
### Motivation

- Add unit tests to cover missing TOTP helper behaviors to prevent regressions in secret/code generation and URI construction.

### Description

- Add `lib/crypt/otp_test.go` containing tests for `GenerateTOTPSecret`, `GetTOTPCode`, `ValidateTOTPCode`, `IsValidTOTPSecret`, and `BuildTotpUri`.
- Test `GenerateTOTPSecret` for expected length and Base32 character set compliance.
- Test round-trip code generation and validation via `GetTOTPCode` and `ValidateTOTPCode`, including remaining-time bounds.
- Test error handling for invalid inputs to `ValidateTOTPCode` and validation behavior of `IsValidTOTPSecret`, and verify URI formatting from `BuildTotpUri` with and without issuer.

### Testing

- Ran `go test ./lib/crypt` and it passed successfully.
- Ran `go test ./lib/...` and the test suite passed for the affected packages.

------
