### PR TITLE
test(common): add missing util helper unit tests

### DIFF
--- a/lib/common/util_test.go
+++ b/lib/common/util_test.go
@@ -3,6 +3,8 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	"net"
+	"sync"
 	"testing"
 )
 
@@ -196,5 +198,131 @@ func TestBinaryWrite(t *testing.T) {
 	want := []byte("info" + CONN_DATA_SEQ + "true" + CONN_DATA_SEQ)
 	if !bytes.Equal(payload, want) {
 		t.Fatalf("payload = %q, want %q", string(payload), string(want))
+	}
+}
+
+func TestArrayAndPortHelpers(t *testing.T) {
+	if !InStrArr([]string{"a", "b"}, "b") || InStrArr([]string{"a", "b"}, "c") {
+		t.Fatalf("InStrArr() returned unexpected result")
+	}
+	if !InIntArr([]int{1, 2, 3}, 2) || InIntArr([]int{1, 2, 3}, 4) {
+		t.Fatalf("InIntArr() returned unexpected result")
+	}
+
+	ports := GetPorts(" 80, 443, 1000-1002,1002-1001,invalid,0,65537")
+	want := []int{80, 443, 1000, 1001, 1002}
+	if len(ports) != len(want) {
+		t.Fatalf("GetPorts() length = %d, want %d (%v)", len(ports), len(want), ports)
+	}
+	for i := range want {
+		if ports[i] != want[i] {
+			t.Fatalf("GetPorts() = %v, want %v", ports, want)
+		}
+	}
+
+	if !IsPort("65536") || IsPort("65537") || IsPort("0") || IsPort("bad") {
+		t.Fatalf("IsPort() returned unexpected result")
+	}
+	if got := FormatAddress("8080"); got != "127.0.0.1:8080" {
+		t.Fatalf("FormatAddress(port) = %q, want %q", got, "127.0.0.1:8080")
+	}
+	if got := FormatAddress("127.0.0.1:8080"); got != "127.0.0.1:8080" {
+		t.Fatalf("FormatAddress(addr) = %q, want %q", got, "127.0.0.1:8080")
+	}
+}
+
+func TestSliceAndMapHelpers(t *testing.T) {
+	trimmed := TrimArr([]string{" a ", "", "  ", "b"})
+	if len(trimmed) != 2 || trimmed[0] != "a" || trimmed[1] != "b" {
+		t.Fatalf("TrimArr() = %v, want [a b]", trimmed)
+	}
+
+	if !IsArrContains([]string{"x", "y"}, "y") || IsArrContains(nil, "x") {
+		t.Fatalf("IsArrContains() returned unexpected result")
+	}
+
+	removed := RemoveArrVal([]string{"a", "b", "c"}, "b")
+	if len(removed) != 2 || removed[0] != "a" || removed[1] != "c" {
+		t.Fatalf("RemoveArrVal() = %v, want [a c]", removed)
+	}
+
+	handled := HandleArrEmptyVal([]string{"a", "", " c ", " "})
+	if len(handled) != 3 || handled[0] != "a" || handled[1] != "a" || handled[2] != "c" {
+		t.Fatalf("HandleArrEmptyVal() = %v, want [a a c]", handled)
+	}
+
+	a1 := []string{"x"}
+	a2 := []string{"m", "n", "o"}
+	a3 := []string{}
+	max := ExtendArrs(&a1, &a2, &a3)
+	if max != 3 {
+		t.Fatalf("ExtendArrs() max = %d, want 3", max)
+	}
+	if len(a1) != 3 || a1[2] != "x" || len(a3) != 3 || a3[0] != "" {
+		t.Fatalf("ExtendArrs() unexpected arrays: a1=%v a3=%v", a1, a3)
+	}
+
+	if got := BytesToNum([]byte{1, 2, 3}); got != 123 {
+		t.Fatalf("BytesToNum() = %d, want 123", got)
+	}
+
+	var m sync.Map
+	m.Store("k1", 1)
+	m.Store("k2", 2)
+	if got := GetSyncMapLen(&m); got != 2 {
+		t.Fatalf("GetSyncMapLen() = %d, want 2", got)
+	}
+}
+
+func TestIPAndBindHelpers(t *testing.T) {
+	v4 := NormalizeIP(net.ParseIP("192.0.2.1"))
+	if v4 == nil || v4.To4() == nil {
+		t.Fatalf("NormalizeIP(v4) = %v, want ipv4", v4)
+	}
+	v6 := NormalizeIP(net.ParseIP("2001:db8::1"))
+	if v6 == nil || v6.To16() == nil || v6.To4() != nil {
+		t.Fatalf("NormalizeIP(v6) = %v, want ipv6", v6)
+	}
+
+	if !IsZeroIP(nil) || !IsZeroIP(net.IPv4zero) || !IsZeroIP(net.IPv6zero) || IsZeroIP(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("IsZeroIP() returned unexpected result")
+	}
+
+	network, addr := BuildUdpBindAddr("203.0.113.1", nil)
+	if network != "udp4" || addr == nil || addr.IP.String() != "203.0.113.1" {
+		t.Fatalf("BuildUdpBindAddr(server v4) = (%q, %v)", network, addr)
+	}
+	network, addr = BuildUdpBindAddr("2001:db8::1", nil)
+	if network != "udp6" || addr == nil || addr.IP.String() != "2001:db8::1" {
+		t.Fatalf("BuildUdpBindAddr(server v6) = (%q, %v)", network, addr)
+	}
+	network, addr = BuildUdpBindAddr("", net.ParseIP("192.0.2.2"))
+	if network != "udp4" || addr == nil || !addr.IP.Equal(net.IPv4zero) {
+		t.Fatalf("BuildUdpBindAddr(client v4) = (%q, %v)", network, addr)
+	}
+	network, addr = BuildUdpBindAddr("", nil)
+	if network != "udp" || addr == nil {
+		t.Fatalf("BuildUdpBindAddr(default) = (%q, %v)", network, addr)
+	}
+
+	if !IsSameIPType("1.1.1.1:80", "2.2.2.2:90") || !IsSameIPType("[2001:db8::1]:80", "[2001:db8::2]:90") || IsSameIPType("1.1.1.1:80", "[2001:db8::2]:90") {
+		t.Fatalf("IsSameIPType() returned unexpected result")
+	}
+
+	if got := BuildTCPBindAddr("127.0.0.1"); got == nil {
+		t.Fatalf("BuildTCPBindAddr(valid) = nil, want non-nil")
+	}
+	if got := BuildTCPBindAddr("bad-ip"); got != nil {
+		t.Fatalf("BuildTCPBindAddr(invalid) = %v, want nil", got)
+	}
+	if got := BuildUDPBindAddr("2001:db8::1"); got == nil {
+		t.Fatalf("BuildUDPBindAddr(valid) = nil, want non-nil")
+	}
+	if got := BuildUDPBindAddr("bad-ip"); got != nil {
+		t.Fatalf("BuildUDPBindAddr(invalid) = %v, want nil", got)
+	}
+
+	if !IsPublicHost("8.8.8.8:53") || IsPublicHost("127.0.0.1:53") || !IsPublicHost("example.com:443") || IsPublicHost(":bad") {
+		t.Fatalf("IsPublicHost() returned unexpected result")
 	}
 }


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for helper utilities in `lib/common` that were previously untested.
- Validate correctness of array, slice, port/address, IP normalization and bind-related helpers to prevent regressions.
- Provide deterministic, fast tests that exercise small, pure functions in `util.go`.

### Description
- Added multiple test cases to `lib/common/util_test.go` covering array/list helpers (`InStrArr`, `InIntArr`, `TrimArr`, `IsArrContains`, `RemoveArrVal`, `HandleArrEmptyVal`, `ExtendArrs`).
- Added tests for port/address helpers (`GetPorts`, `IsPort`, `FormatAddress`, `BytesToNum`, `GetSyncMapLen`) and expanded imports (`net`, `sync`).
- Added IP and bind related tests (`NormalizeIP`, `IsZeroIP`, `BuildUdpBindAddr`, `IsSameIPType`, `BuildTCPBindAddr`, `BuildUDPBindAddr`, `IsPublicHost`) and assertions for existing helpers.

### Testing
- Ran `go test ./lib/common` and all tests succeeded (`ok`).

------
