### PR TITLE
test: add missing unit tests for goroutine CopyBuffer and sheap IntHeap

### DIFF
--- a/lib/goroutine/pool_test.go
+++ b/lib/goroutine/pool_test.go
@@ -1,0 +1,60 @@
+package goroutine
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/djylb/nps/lib/file"
+)
+
+func TestCopyBuffer_HTTPDetectionAndCopy(t *testing.T) {
+	input := "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n"
+	src := bytes.NewBufferString(input)
+	var dst bytes.Buffer
+
+	task := &file.Tunnel{Target: &file.Target{TargetStr: "127.0.0.1:80"}}
+	written, err := CopyBuffer(&dst, src, nil, task, "127.0.0.1:12345")
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got %v", err)
+	}
+	if written != int64(len(input)) {
+		t.Fatalf("unexpected written bytes, got=%d want=%d", written, len(input))
+	}
+	if dst.String() != input {
+		t.Fatalf("unexpected copied content, got=%q want=%q", dst.String(), input)
+	}
+	if !task.IsHttp {
+		t.Fatalf("expected task.IsHttp=true for HTTP request")
+	}
+}
+
+func TestCopyBuffer_FlowLimitExceeded(t *testing.T) {
+	src := bytes.NewBufferString("abcd")
+	var dst bytes.Buffer
+
+	flow := &file.Flow{FlowLimit: 1, ExportFlow: (1 << 20) - 2}
+	written, err := CopyBuffer(&dst, src, []*file.Flow{flow}, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "flow limit exceeded") {
+		t.Fatalf("expected flow limit exceeded error, got %v", err)
+	}
+	if written != 4 {
+		t.Fatalf("unexpected written bytes, got=%d want=4", written)
+	}
+}
+
+func TestCopyBuffer_TimeLimitExceeded(t *testing.T) {
+	src := bytes.NewBufferString("abc")
+	var dst bytes.Buffer
+
+	flow := &file.Flow{TimeLimit: time.Now().Add(-time.Second)}
+	written, err := CopyBuffer(&dst, src, []*file.Flow{flow}, nil, "")
+	if err == nil || !strings.Contains(err.Error(), "time limit exceeded") {
+		t.Fatalf("expected time limit exceeded error, got %v", err)
+	}
+	if written != 3 {
+		t.Fatalf("unexpected written bytes, got=%d want=3", written)
+	}
+}

--- a/lib/sheap/heap_test.go
+++ b/lib/sheap/heap_test.go
@@ -1,0 +1,41 @@
+package sheap
+
+import (
+	"container/heap"
+	"reflect"
+	"testing"
+)
+
+func TestIntHeap_MinOrderAndPushPop(t *testing.T) {
+	h := &IntHeap{5, 1, 3}
+	heap.Init(h)
+
+	heap.Push(h, int64(2))
+	heap.Push(h, int64(4))
+
+	var got []int64
+	for h.Len() > 0 {
+		got = append(got, heap.Pop(h).(int64))
+	}
+
+	want := []int64{1, 2, 3, 4, 5}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected pop order, got=%v want=%v", got, want)
+	}
+}
+
+func TestIntHeap_SwapLessAndLen(t *testing.T) {
+	h := IntHeap{10, 20}
+
+	if h.Len() != 2 {
+		t.Fatalf("unexpected Len(): %d", h.Len())
+	}
+	if !h.Less(0, 1) {
+		t.Fatalf("Less(0,1) should be true for 10 < 20")
+	}
+
+	h.Swap(0, 1)
+	if h[0] != 20 || h[1] != 10 {
+		t.Fatalf("Swap did not swap elements, heap=%v", h)
+	}
+}


### PR DESCRIPTION
### Motivation
- Fill previously missing unit tests to improve package coverage for core helpers in `lib/goroutine` and `lib/sheap`.
- Ensure `CopyBuffer` and `IntHeap` behaviors (including edge cases) are validated to prevent regressions.

### Description
- Add `lib/goroutine/pool_test.go` with tests for `CopyBuffer` covering HTTP request detection, copy correctness, `flow limit exceeded` path, and `time limit exceeded` path.
- Add `lib/sheap/heap_test.go` with tests for `IntHeap` covering min-heap ordering, `Push`/`Pop` behavior, and basic helpers `Len`, `Less`, and `Swap`.
- Tests exercise realistic small inputs and assert both returned errors and written byte counts/ordering.

### Testing
- Ran `go test ./lib/sheap ./lib/goroutine` and both packages passed (`ok`).
- Local package-level tests executed verify the new assertions for `CopyBuffer` and `IntHeap` and succeeded.

------
