### PR TITLE
test: 补全 common run 工具单元测试

### DIFF
--- a/lib/common/run_test.go
+++ b/lib/common/run_test.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetInstallPathWithConfPath(t *testing.T) {
+	oldConf := ConfPath
+	defer func() { ConfPath = oldConf }()
+
+	ConfPath = "/tmp/custom-nps"
+	if got := GetInstallPath(); got != ConfPath {
+		t.Fatalf("GetInstallPath() = %q, want %q", got, ConfPath)
+	}
+}
+
+func TestGetRunPathUsesInstallPathWhenExists(t *testing.T) {
+	oldConf := ConfPath
+	defer func() { ConfPath = oldConf }()
+	oldArgs := append([]string(nil), os.Args...)
+	defer func() { os.Args = oldArgs }()
+
+	tmp := t.TempDir()
+	ConfPath = tmp
+	os.Args = []string{"nps", "-c", "conf/nps.conf"}
+
+	if got := GetRunPath(); got != tmp {
+		t.Fatalf("GetRunPath() = %q, want %q", got, tmp)
+	}
+}
+
+func TestGetRunPathFallsBackToAppPathWhenInstallPathMissing(t *testing.T) {
+	oldConf := ConfPath
+	defer func() { ConfPath = oldConf }()
+	oldArgs := append([]string(nil), os.Args...)
+	defer func() { os.Args = oldArgs }()
+
+	ConfPath = filepath.Join(t.TempDir(), "not-exist")
+	os.Args = []string{"nps", "-c", "conf/nps.conf"}
+
+	want := GetAppPath()
+	if got := GetRunPath(); got != want {
+		t.Fatalf("GetRunPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	abs := "/var/log/nps.log"
+	if got := ResolvePath(abs); got != abs {
+		t.Fatalf("ResolvePath() absolute = %q, want %q", got, abs)
+	}
+
+	oldConf := ConfPath
+	defer func() { ConfPath = oldConf }()
+	oldArgs := append([]string(nil), os.Args...)
+	defer func() { os.Args = oldArgs }()
+
+	runPath := t.TempDir()
+	ConfPath = runPath
+	os.Args = []string{"nps", "-c", "conf/nps.conf"}
+
+	rel := "conf/nps.conf"
+	want := filepath.Join(runPath, rel)
+	if got := ResolvePath(rel); got != want {
+		t.Fatalf("ResolvePath() relative = %q, want %q", got, want)
+	}
+}
+
+func TestRunTimeAndSecs(t *testing.T) {
+	oldStart := StartTime
+	defer func() { StartTime = oldStart }()
+
+	StartTime = time.Now().Add(-(24*time.Hour + 2*time.Hour + 3*time.Minute + 4*time.Second))
+
+	runtimeText := GetRunTime()
+	for _, token := range []string{"1d", "2h", "3m", "4s"} {
+		if !strings.Contains(runtimeText, token) {
+			t.Fatalf("GetRunTime() = %q, missing %q", runtimeText, token)
+		}
+	}
+
+	min := int64(24*3600 + 2*3600 + 3*60 + 4)
+	if got := GetRunSecs(); got < min {
+		t.Fatalf("GetRunSecs() = %d, want >= %d", got, min)
+	}
+
+	if got := GetStartTime(); got != StartTime.Unix() {
+		t.Fatalf("GetStartTime() = %d, want %d", got, StartTime.Unix())
+	}
+}


### PR DESCRIPTION
### Motivation

- 补全 `lib/common/run.go` 中缺失的单元测试以提高路径解析与运行时辅助函数的覆盖率并防止回归。

### Description

- 新增测试文件 `lib/common/run_test.go`，覆盖 `GetInstallPath`、`GetRunPath`（安装路径存在/不存在两种场景）、`ResolvePath`（绝对/相对路径）以及运行时间相关的 `GetRunTime`、`GetRunSecs`、`GetStartTime`。 
- 测试中对全局变量 `ConfPath`、`StartTime` 与进程参数 `os.Args` 进行了备份与恢复以避免影响其它测试。
- 使用 `t.TempDir()` 创建临时路径以验证安装路径存在与相对路径解析行为。

### Testing

- 运行 `go test ./lib/common`，测试通过。
- 运行 `go test ./...`，所有测试通过。

------
