### PR TITLE
test(conn): 补全 util 单元测试

### DIFF
--- a/lib/conn/util_test.go
+++ b/lib/conn/util_test.go
@@ -1,0 +1,109 @@
+package conn
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+)
+
+type fakeNetError struct {
+	msg       string
+	temporary bool
+	timeout   bool
+}
+
+func (e fakeNetError) Error() string   { return e.msg }
+func (e fakeNetError) Temporary() bool { return e.temporary }
+func (e fakeNetError) Timeout() bool   { return e.timeout }
+
+func TestGetLenBytes(t *testing.T) {
+	payload := []byte("hello")
+	got, err := GetLenBytes(payload)
+	if err != nil {
+		t.Fatalf("GetLenBytes() error = %v", err)
+	}
+
+	if len(got) != 4+len(payload) {
+		t.Fatalf("GetLenBytes() len = %d, want %d", len(got), 4+len(payload))
+	}
+
+	var n int32
+	if err := binary.Read(bytes.NewReader(got[:4]), binary.LittleEndian, &n); err != nil {
+		t.Fatalf("binary.Read(len) error = %v", err)
+	}
+	if int(n) != len(payload) {
+		t.Fatalf("encoded length = %d, want %d", n, len(payload))
+	}
+	if !bytes.Equal(got[4:], payload) {
+		t.Fatalf("payload = %q, want %q", got[4:], payload)
+	}
+}
+
+func TestIsTempOrTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "net temporary", err: fakeNetError{msg: "temp", temporary: true}, want: true},
+		{name: "net timeout", err: fakeNetError{msg: "timeout", timeout: true}, want: true},
+		{name: "plain timeout text", err: io.EOF, want: false},
+		{name: "plain timeout text", err: io.ErrNoProgress, want: false},
+		{name: "net.Error without timeout flag", err: &net.DNSError{Err: "i/o timeout"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTempOrTimeout(tt.err); got != tt.want {
+				t.Fatalf("IsTempOrTimeout(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteACKAndReadACK(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- WriteACK(server, 2*time.Second)
+	}()
+
+	if err := ReadACK(client, 2*time.Second); err != nil {
+		t.Fatalf("ReadACK() error = %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("WriteACK() error = %v", err)
+	}
+}
+
+func TestReadACKUnexpectedValue(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_ = server.SetWriteDeadline(time.Now().Add(2 * time.Second))
+		_, err := server.Write([]byte("NAK"))
+		errCh <- err
+	}()
+
+	err := ReadACK(client, 2*time.Second)
+	if err == nil {
+		t.Fatal("ReadACK() error = nil, want non-nil")
+	}
+	if err != io.ErrUnexpectedEOF {
+		t.Fatalf("ReadACK() error = %v, want %v", err, io.ErrUnexpectedEOF)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("server write error = %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- 增补 `lib/conn` 包中缺失的单元测试以覆盖常用工具函数的行为，提升回归安全性。
- 重点覆盖二进制长度封装、网络超时判定和 ACK 握手相关逻辑的边界情况。

### Description
- 新增测试文件 `lib/conn/util_test.go`，包含对 `GetLenBytes` 的长度与 payload 拼接验证测试。 
- 为 `IsTempOrTimeout` 添加表驱动测试，使用 `fakeNetError` 模拟 `net.Error` 的 `Temporary`/`Timeout` 行为并验证非网络错误分支。 
- 为 `WriteACK` 与 `ReadACK` 添加正常握手与异常 ACK 内容（返回 `io.ErrUnexpectedEOF`）的测试，使用 `net.Pipe` 做本地连接对等通信。 
- 在测试中避免对当前不可用常量的依赖（直接写入测试用的意外 ACK 字符串）。

### Testing
- 运行过针对包的快速测试 `go test ./lib/conn -run 'Test(GetLenBytes|IsTempOrTimeout|WriteACKAndReadACK|ReadACKUnexpectedValue)$' -v -timeout 20s`，所有测试通过。 
- 运行过更广泛的包测试 `go test ./lib/conn -timeout 60s`，结果通过。

------
