### PR TITLE
test: add coverage for server status buffer helper logic

### DIFF
--- a/server/tool/utils_test.go
+++ b/server/tool/utils_test.go
@@ -1,0 +1,107 @@
+package tool
+
+import "testing"
+
+func resetStatusState() {
+	ssMu.Lock()
+	defer ssMu.Unlock()
+	for i := range statBuf {
+		statBuf[i] = nil
+	}
+	statIdx = 0
+	statFilled = false
+}
+
+func fillStatusEntries(n int) {
+	for i := 0; i < n; i++ {
+		statBuf[i] = map[string]interface{}{"id": i}
+	}
+	statIdx = n
+	if n >= statusCap {
+		statIdx = n % statusCap
+		statFilled = true
+	}
+}
+
+func TestStatusCountAndSnapshotWithoutWrap(t *testing.T) {
+	resetStatusState()
+	fillStatusEntries(3)
+
+	if got := statusCount(); got != 3 {
+		t.Fatalf("statusCount()=%d, want 3", got)
+	}
+
+	snapshot := StatusSnapshot()
+	if len(snapshot) != 3 {
+		t.Fatalf("len(StatusSnapshot())=%d, want 3", len(snapshot))
+	}
+
+	for i := 0; i < 3; i++ {
+		if snapshot[i]["id"].(int) != i {
+			t.Fatalf("snapshot[%d].id=%v, want %d", i, snapshot[i]["id"], i)
+		}
+	}
+}
+
+func TestStatusSnapshotWithWrap(t *testing.T) {
+	resetStatusState()
+	ssMu.Lock()
+	for i := 0; i < statusCap; i++ {
+		statBuf[i] = map[string]interface{}{"id": i}
+	}
+	statIdx = 100
+	statFilled = true
+	ssMu.Unlock()
+
+	snapshot := StatusSnapshot()
+	if len(snapshot) != statusCap {
+		t.Fatalf("len(StatusSnapshot())=%d, want %d", len(snapshot), statusCap)
+	}
+	if snapshot[0]["id"].(int) != 100 {
+		t.Fatalf("snapshot[0].id=%v, want 100", snapshot[0]["id"])
+	}
+	if snapshot[len(snapshot)-1]["id"].(int) != 99 {
+		t.Fatalf("snapshot[last].id=%v, want 99", snapshot[len(snapshot)-1]["id"])
+	}
+}
+
+func TestChartDecilesEdgeCasesAndSampling(t *testing.T) {
+	resetStatusState()
+	if got := ChartDeciles(); got != nil {
+		t.Fatalf("ChartDeciles()=%v, want nil for empty state", got)
+	}
+
+	resetStatusState()
+	fillStatusEntries(5)
+	small := ChartDeciles()
+	if len(small) != 5 {
+		t.Fatalf("len(ChartDeciles())=%d, want 5", len(small))
+	}
+	for i := 0; i < 5; i++ {
+		if small[i]["id"].(int) != i {
+			t.Fatalf("small[%d].id=%v, want %d", i, small[i]["id"], i)
+		}
+	}
+
+	resetStatusState()
+	ssMu.Lock()
+	for i := 0; i < statusCap; i++ {
+		statBuf[i] = map[string]interface{}{"id": i}
+	}
+	statIdx = 100
+	statFilled = true
+	ssMu.Unlock()
+
+	deciles := ChartDeciles()
+	if len(deciles) != 10 {
+		t.Fatalf("len(ChartDeciles())=%d, want 10", len(deciles))
+	}
+
+	for i := 0; i < 10; i++ {
+		pos := (i * (statusCap - 1)) / 9
+		expected := (100 + pos) % statusCap
+		if deciles[i]["id"].(int) != expected {
+			t.Fatalf("deciles[%d].id=%v, want %d", i, deciles[i]["id"], expected)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation

- The server status ring buffer helpers lacked unit tests covering non-wrap and wrap-around behaviors, and `ChartDeciles` sampling/edge-cases needed validation.
- Deterministic helpers are required to set up/teardown internal ring-buffer state (`statBuf`, `statIdx`, `statFilled`) for stable tests.

### Description

- Add `server/tool/utils_test.go` which provides helper functions `resetStatusState` and `fillStatusEntries` to prepare deterministic ring-buffer state for tests.
- Add tests for `statusCount` and `StatusSnapshot` in a non-wrap scenario to validate count, length and ordering.
- Add tests for `StatusSnapshot` with a wrapped buffer (`statFilled=true` and non-zero `statIdx`) to validate output order across the wrap boundary.
- Add tests for `ChartDeciles` to cover empty state (`nil`), small samples (<=10 returning full dataset), and large samples (>10) returning 10 sampled deciles with correct index computation.

### Testing

- Ran `go test ./server/tool ./...` and the package tests passed successfully.
- A prior `go test ./... -count=1` run showed no failing packages across the repository.

------
