### PR TITLE
test: 补全 server/proxy/base 的缺失单元测试

### DIFF
--- a/server/proxy/base_test.go
+++ b/server/proxy/base_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/djylb/nps/lib/file"
+)
+
+func TestIn(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		list   []string
+		want   bool
+	}{
+		{name: "finds existing element", target: "b", list: []string{"c", "a", "b"}, want: true},
+		{name: "returns false for missing element", target: "d", list: []string{"c", "a", "b"}, want: false},
+		{name: "handles empty slice", target: "a", list: []string{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := in(tt.target, tt.list); got != tt.want {
+				t.Fatalf("in(%q, %v) = %v, want %v", tt.target, tt.list, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckFlowAndConnNum(t *testing.T) {
+	s := &BaseServer{}
+
+	t.Run("expired service", func(t *testing.T) {
+		client := &file.Client{Flow: &file.Flow{TimeLimit: time.Now().Add(-time.Second)}}
+		err := s.CheckFlowAndConnNum(client)
+		if err == nil || err.Error() != "service access expired" {
+			t.Fatalf("CheckFlowAndConnNum() error = %v, want service access expired", err)
+		}
+	})
+
+	t.Run("traffic limit exceeded", func(t *testing.T) {
+		client := &file.Client{Flow: &file.Flow{FlowLimit: 1, ExportFlow: 1 << 20, InletFlow: 1}, MaxConn: 10}
+		err := s.CheckFlowAndConnNum(client)
+		if err == nil || err.Error() != "traffic limit exceeded" {
+			t.Fatalf("CheckFlowAndConnNum() error = %v, want traffic limit exceeded", err)
+		}
+	})
+
+	t.Run("connection limit exceeded", func(t *testing.T) {
+		client := &file.Client{Flow: &file.Flow{}, MaxConn: 1, NowConn: 1}
+		err := s.CheckFlowAndConnNum(client)
+		if err == nil || err.Error() != "connection limit exceeded" {
+			t.Fatalf("CheckFlowAndConnNum() error = %v, want connection limit exceeded", err)
+		}
+	})
+
+	t.Run("success increments connection count", func(t *testing.T) {
+		client := &file.Client{Flow: &file.Flow{}, MaxConn: 2, NowConn: 0}
+		err := s.CheckFlowAndConnNum(client)
+		if err != nil {
+			t.Fatalf("CheckFlowAndConnNum() unexpected error = %v", err)
+		}
+		if client.NowConn != 1 {
+			t.Fatalf("client.NowConn = %d, want 1", client.NowConn)
+		}
+	})
+}


### PR DESCRIPTION
### Motivation
- 补全缺失的单元测试以覆盖 `in` 辅助函数的边界行为和 `BaseServer.CheckFlowAndConnNum` 的关键分支逻辑。
- 提高代码回归保护，确保访问过期、流量限制、连接数限制及正常路径均被验证。

### Description
- 新增测试文件 `server/proxy/base_test.go`，包含对 `in` 函数的表驱动测试以验证命中、未命中和空切片场景。
- 为 `BaseServer.CheckFlowAndConnNum` 增加子测试，覆盖服务过期、流量超限、连接数超限以及正常通过并递增连接数四个分支。
- 仅新增测试文件，不修改生产逻辑代码或其他源码。

### Testing
- 运行 `go test ./server/proxy` 并通过，测试包 `server/proxy` 结果为 OK。
- 运行 `go test ./...` 并通过，所有可运行的测试包均已通过。

------
