### PR TITLE
test: 补全 lib/install 缺失的单元测试

### DIFF
--- a/lib/install/install_test.go
+++ b/lib/install/install_test.go
@@ -1,0 +1,142 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPathExists(t *testing.T) {
+	tmp := t.TempDir()
+
+	exists, err := pathExists(tmp)
+	if err != nil {
+		t.Fatalf("pathExists(existing dir) error = %v", err)
+	}
+	if !exists {
+		t.Fatal("pathExists(existing dir) = false, want true")
+	}
+
+	missing := filepath.Join(tmp, "missing")
+	exists, err = pathExists(missing)
+	if err != nil {
+		t.Fatalf("pathExists(missing path) error = %v", err)
+	}
+	if exists {
+		t.Fatal("pathExists(missing path) = true, want false")
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "source.txt")
+	content := []byte("hello-nps")
+	if err := os.WriteFile(src, content, 0o644); err != nil {
+		t.Fatalf("WriteFile(src) error = %v", err)
+	}
+
+	dest := filepath.Join(tmp, "nested", "dest.txt")
+	n, err := copyFile(src, dest)
+	if err != nil {
+		t.Fatalf("copyFile() error = %v", err)
+	}
+	if n != int64(len(content)) {
+		t.Fatalf("copyFile() bytes = %d, want %d", n, len(content))
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("ReadFile(dest) error = %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("dest content = %q, want %q", got, content)
+	}
+}
+
+func TestCopyFileSamePathNoop(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "same.txt")
+	if err := os.WriteFile(file, []byte("same"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	n, err := copyFile(file, file)
+	if err != nil {
+		t.Fatalf("copyFile(same,same) error = %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("copyFile(same,same) bytes = %d, want 0", n)
+	}
+}
+
+func TestCopyDir(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src")
+	dest := filepath.Join(tmp, "dest")
+
+	if err := os.MkdirAll(filepath.Join(src, "child"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(src) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "root.txt"), []byte("root"), 0o644); err != nil {
+		t.Fatalf("WriteFile(root.txt) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "child", "leaf.txt"), []byte("leaf"), 0o644); err != nil {
+		t.Fatalf("WriteFile(leaf.txt) error = %v", err)
+	}
+
+	if err := CopyDir(src, dest); err != nil {
+		t.Fatalf("CopyDir() error = %v", err)
+	}
+
+	for rel, want := range map[string]string{
+		"root.txt":       "root",
+		"child/leaf.txt": "leaf",
+	} {
+		got, err := os.ReadFile(filepath.Join(dest, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", rel, err)
+		}
+		if string(got) != want {
+			t.Fatalf("content %s = %q, want %q", rel, got, want)
+		}
+	}
+}
+
+func TestCopyDirValidationErrors(t *testing.T) {
+	tmp := t.TempDir()
+	srcFile := filepath.Join(tmp, "src-file")
+	if err := os.WriteFile(srcFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(srcFile) error = %v", err)
+	}
+	if err := CopyDir(srcFile, filepath.Join(tmp, "dest")); err == nil {
+		t.Fatal("CopyDir(src file, dir) error = nil, want non-nil")
+	}
+
+	srcDir := filepath.Join(tmp, "src-dir")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(srcDir) error = %v", err)
+	}
+	destFile := filepath.Join(tmp, "dest-file")
+	if err := os.WriteFile(destFile, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(destFile) error = %v", err)
+	}
+	if err := CopyDir(srcDir, destFile); err == nil {
+		t.Fatal("CopyDir(src dir, dest file) error = nil, want non-nil")
+	}
+}
+
+func TestMkidrDirAll(t *testing.T) {
+	tmp := t.TempDir()
+	MkidrDirAll(tmp, "a", filepath.Join("b", "c"))
+
+	for _, rel := range []string{"a", filepath.Join("b", "c")} {
+		p := filepath.Join(tmp, rel)
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("Stat(%s) error = %v", p, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("%s is not a directory", p)
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- 补齐 `lib/install` 中文件/目录工具函数的缺失单元测试以提高回归防护并覆盖关键边界行为。

### Description
- 新增测试文件 `lib/install/install_test.go`，为 `pathExists`、`copyFile`、`CopyDir` 和 `MkidrDirAll` 添加单元测试。
- `copyFile` 的测试覆盖了正常复制并自动创建目标父目录以及源/目标同路径时的 no-op 行为（使用 `copyFile` 验证）。
- `CopyDir` 的测试覆盖了递归复制嵌套目录与文件的成功路径以及 `srcPath` 不是目录 / `destPath` 不是目录 时的错误分支（使用 `CopyDir` 验证）。
- 添加了针对批量目录创建函数 `MkidrDirAll` 的存在性断言测试（使用 `MkidrDirAll` 验证）。

### Testing
- 运行 `go test ./lib/install ./server/tool`，两个包的测试均通过。
- 运行 `go test ./...`，测试通过（部分包结果为 cached/无测试文件）。
- 尝试运行覆盖收集 `go test ./... -cover` 时因本地 Go 工具链版本不匹配（`go1.26.0` vs `go1.25.1`）导致失败，但新增单元测试本身在正常 `go test` 情况下已验证通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7e91742083319289365acffb041d)