### PR TITLE
fix(mux): guard nil fd close on Windows

### DIFF
--- a/lib/mux/mux.go
+++ b/lib/mux/mux.go
@@ -585,6 +585,9 @@ func (Self *Bandwidth) Get() (bw float64) {
 }
 
 func (Self *Bandwidth) Close() error {
+	if Self.fd == nil {
+		return nil
+	}
 	return Self.fd.Close()
 }
 


### PR DESCRIPTION
### Motivation
- Prevent a nil-pointer close when `Bandwidth.Close()` is called on Windows where `getConnFd` intentionally returns nil, which could lead to crashes or resource instability.

### Description
- Add a nil-check in `Bandwidth.Close()` to return early when `Self.fd == nil` before calling `Close()` on the file descriptor.

### Testing
- Ran `go test ./lib/mux ./lib/conn` which passed; compiled Windows test binary with `GOOS=windows GOARCH=amd64 go test -c ./lib/mux` which succeeded; attempting to run Windows tests in the Linux environment produced an `exec format error` as expected for cross-platform run attempts.

------
