### PR TITLE
test: reduce unit test environment coupling

### DIFF
--- a/lib/cache/cert_test.go
+++ b/lib/cache/cert_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -42,7 +43,10 @@ func TestCertManagerFileNotFoundAndIdleEviction(t *testing.T) {
 	m := NewCertManager(10, 0, 0)
 	defer m.Stop()
 
-	_, err := m.Get("/tmp/not-exists-cert.pem", "/tmp/not-exists-key.pem", "file", "missing")
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "not-exists-cert.pem")
+	keyPath := filepath.Join(tmpDir, "not-exists-key.pem")
+	_, err := m.Get(certPath, keyPath, "file", "missing")
 	if err == nil || !strings.Contains(err.Error(), "cert file not found") {
 		t.Fatalf("expected cert file not found error, got %v", err)
 	}

--- a/lib/common/run_test.go
+++ b/lib/common/run_test.go
@@ -12,7 +12,7 @@ func TestGetInstallPathWithConfPath(t *testing.T) {
 	oldConf := ConfPath
 	defer func() { ConfPath = oldConf }()
 
-	ConfPath = "/tmp/custom-nps"
+	ConfPath = filepath.Join(t.TempDir(), "custom-nps")
 	if got := GetInstallPath(); got != ConfPath {
 		t.Fatalf("GetInstallPath() = %q, want %q", got, ConfPath)
 	}
@@ -49,7 +49,10 @@ func TestGetRunPathFallsBackToAppPathWhenInstallPathMissing(t *testing.T) {
 }
 
 func TestResolvePath(t *testing.T) {
-	abs := "/var/log/nps.log"
+	abs, err := filepath.Abs(filepath.Join(".", "nps.log"))
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
 	if got := ResolvePath(abs); got != abs {
 		t.Fatalf("ResolvePath() absolute = %q, want %q", got, abs)
 	}

--- a/lib/mux/mux_test.go
+++ b/lib/mux/mux_test.go
@@ -13,6 +13,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -41,6 +42,9 @@ var dataSize = 1024 * 1024 * 100
 
 func requireIntegrationEnv(t *testing.T) {
 	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skipf("integration test skipped: requires linux, current GOOS=%s", runtime.GOOS)
+	}
 	if os.Getenv("NPS_RUN_INTEGRATION_TESTS") != "1" {
 		t.Skip("integration test skipped: set NPS_RUN_INTEGRATION_TESTS=1 to enable")
 	}


### PR DESCRIPTION
### Motivation

- Reduce tests' dependence on fixed host filesystem paths and platform assumptions to avoid cross-platform fragility and accidental external side effects.
- Ensure unit tests remain fast and isolated by preventing heavy integration flows from running in typical unit-test runs.

### Description

- Updated `lib/common/run_test.go` to avoid hard-coded absolute paths by using `t.TempDir()` for install path inputs and constructing an absolute test path with `filepath.Abs` instead of `/var`-style literals.
- Updated `lib/cache/cert_test.go` to use a temporary test directory via `t.TempDir()` and `filepath.Join` for non-existent cert/key paths instead of `/tmp/...` constants.
- Strengthened integration gating in `lib/mux/mux_test.go` by checking `runtime.GOOS` and skipping the test if not `linux` before assessing environment variables and required tools.
- Added necessary imports (`filepath`, `runtime`) where required to support the above changes.

### Testing

- Ran `go test ./...` and all test packages completed successfully (unit tests passed and integration tests remain skipped by default). 
- Ran `go test ./lib/mux -run TestMux -v` which yielded the integration test skip gate as expected and passed (skipped).

------
