### PR TITLE
test: expand config parser unit coverage

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -5,6 +5,26 @@ import (
 	"testing"
 )
 
+func TestGetAllTitle_DuplicateRejected(t *testing.T) {
+	_, err := getAllTitle("[common]\na=1\n[common]\nb=2\n")
+	if err == nil {
+		t.Fatalf("expected duplicate title to return an error")
+	}
+}
+
+func TestGetAllTitle_ParseAll(t *testing.T) {
+	titles, err := getAllTitle("[common]\na=1\n[web]\nhost=a.com\n[tcp]\nmode=tcp\n")
+	if err != nil {
+		t.Fatalf("getAllTitle returned error: %v", err)
+	}
+	if len(titles) != 3 {
+		t.Fatalf("expected 3 titles, got %d", len(titles))
+	}
+	if titles[0] != "[common]" || titles[1] != "[web]" || titles[2] != "[tcp]" {
+		t.Fatalf("unexpected title order/content: %#v", titles)
+	}
+}
+
 func TestReg(t *testing.T) {
 	content := `
 [common]
@@ -116,5 +136,100 @@ func TestStripCommentLines(t *testing.T) {
 	cleaned := stripCommentLines(content)
 	if cleaned != "a=1\nb=2\n" {
 		t.Fatalf("unexpected cleaned config: %q", cleaned)
+	}
+}
+
+func TestDealHost_HeaderAndResponseMapping(t *testing.T) {
+	h := dealHost(`host=example.com
+target_addr=127.0.0.1:8080,127.0.0.1:8081
+proxy_protocol=2
+auto_cors=true
+header_X-Test=test-value
+response_Cache-Control=no-cache`)
+
+	if h.Host != "example.com" {
+		t.Fatalf("unexpected host: %s", h.Host)
+	}
+	if h.Target.TargetStr != "127.0.0.1:8080\n127.0.0.1:8081" {
+		t.Fatalf("unexpected target addresses: %q", h.Target.TargetStr)
+	}
+	if h.Target.ProxyProtocol != 2 {
+		t.Fatalf("unexpected proxy protocol: %d", h.Target.ProxyProtocol)
+	}
+	if !h.AutoCORS {
+		t.Fatalf("auto_cors not parsed")
+	}
+	if h.HeaderChange != "X-Test:test-value\n" {
+		t.Fatalf("unexpected header mapping: %q", h.HeaderChange)
+	}
+	if h.RespHeaderChange != "Cache-Control:no-cache\n" {
+		t.Fatalf("unexpected response header mapping: %q", h.RespHeaderChange)
+	}
+}
+
+func TestDealTunnel_ParseFlagsAndRules(t *testing.T) {
+	tnl := dealTunnel(`server_port=10080
+server_ip=0.0.0.0
+mode=http
+target_addr=127.0.0.1:80,127.0.0.1:8080
+proxy_protocol=1
+password=pwd
+socks5_proxy=true
+http_proxy=false
+dest_acl_mode=2
+dest_acl_rules=10.0.0.0/8,192.168.0.0/16
+local_path=/tmp
+strip_pre=/api
+read_only=true`)
+
+	if tnl.Ports != "10080" || tnl.ServerIp != "0.0.0.0" || tnl.Mode != "http" {
+		t.Fatalf("basic tunnel fields parse failed: %+v", tnl)
+	}
+	if tnl.Target.TargetStr != "127.0.0.1:80\n127.0.0.1:8080" {
+		t.Fatalf("unexpected target addresses: %q", tnl.Target.TargetStr)
+	}
+	if !tnl.Socks5Proxy || tnl.HttpProxy {
+		t.Fatalf("proxy flags parse failed: socks5=%v http=%v", tnl.Socks5Proxy, tnl.HttpProxy)
+	}
+	if tnl.DestAclMode != 2 || tnl.DestAclRules != "10.0.0.0/8\n192.168.0.0/16" {
+		t.Fatalf("dest acl parse failed: mode=%d rules=%q", tnl.DestAclMode, tnl.DestAclRules)
+	}
+	if tnl.LocalPath != "/tmp" || tnl.StripPre != "/api" || !tnl.ReadOnly {
+		t.Fatalf("path/read-only parse failed: %+v", tnl)
+	}
+}
+
+func TestDealMultiUser_IgnoreInvalidAndComments(t *testing.T) {
+	accounts := dealMultiUser("\n#comment\nalice = a1\nbob=b2\ncharlie\n =drop\n")
+
+	if len(accounts) != 3 {
+		t.Fatalf("unexpected account count: %#v", accounts)
+	}
+	if accounts["alice"] != "a1" || accounts["bob"] != "b2" || accounts["charlie"] != "" {
+		t.Fatalf("unexpected account map: %#v", accounts)
+	}
+	if _, ok := accounts[""]; ok {
+		t.Fatalf("empty key should be ignored: %#v", accounts)
+	}
+}
+
+func TestDelLocalService_ParseAllFields(t *testing.T) {
+	local := delLocalService(`local_port=9000
+local_type=tcp
+local_ip=127.0.0.1
+password=secret
+target_addr=10.0.0.1:22
+target_type=tcp
+local_proxy=true
+fallback_secret=true`)
+
+	if local.Port != 9000 || local.Type != "tcp" || local.Ip != "127.0.0.1" {
+		t.Fatalf("basic local fields parse failed: %+v", local)
+	}
+	if local.Password != "secret" || local.Target != "10.0.0.1:22" || local.TargetType != "tcp" {
+		t.Fatalf("target/auth parse failed: %+v", local)
+	}
+	if !local.LocalProxy || !local.Fallback {
+		t.Fatalf("boolean flags parse failed: %+v", local)
 	}
 }


### PR DESCRIPTION
### Motivation

- Increase unit test coverage for the configuration parser to exercise missing branches and edge cases in parsing helpers.
- Make tests reliable and fast by avoiding network, filesystem side-effects, or external processes and using inline config strings.

### Description

- Added new unit tests in `lib/config/config_test.go` for `getAllTitle` to verify normal parsing and duplicate-section error behavior.
- Added tests for `dealHost` to validate header/response-header mapping, `target_addr` splitting, numeric and boolean field parsing, and `AutoCORS` handling.
- Added tests for `dealTunnel`, `dealMultiUser`, and `delLocalService` to cover proxy flags, ACL parsing, path/read-only flags, comment/invalid-line handling, and local service field parsing.
- All new tests use inline strings and existing helper functions only, avoiding external dependencies to reduce coupling.

### Testing

- Ran `go test ./lib/config` which passed successfully.
- Ran `go test ./lib/config -cover` which passed and reported `coverage: 53.0% of statements` for the `lib/config` package.
- Ran `go test ./...` which completed successfully for the repository test set.

------
