### PR TITLE
test(config): add missing config parsing unit tests and increase coverage

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 )
@@ -116,5 +118,188 @@ func TestStripCommentLines(t *testing.T) {
 	cleaned := stripCommentLines(content)
 	if cleaned != "a=1\nb=2\n" {
 		t.Fatalf("unexpected cleaned config: %q", cleaned)
+	}
+}
+
+func TestDealHostAndHealth(t *testing.T) {
+	h := dealHost(`host=example.com
+target_addr=127.0.0.1:8080,127.0.0.1:8081
+proxy_protocol=1
+host_change=backend.internal
+scheme=https
+location=/api
+path_rewrite=/v1
+https_just_proxy=true
+auto_ssl=true
+auto_https=true
+auto_cors=true
+compat_mode=true
+redirect_url=https://redirect
+target_is_https=true
+header_x-trace=trace
+response_x-server=nps`)
+
+	if h.Host != "example.com" || h.Scheme != "https" {
+		t.Fatalf("host basic fields parse failed: %+v", h)
+	}
+	if h.Target.TargetStr != "127.0.0.1:8080\n127.0.0.1:8081" || h.Target.ProxyProtocol != 1 {
+		t.Fatalf("host target parse failed: %+v", h.Target)
+	}
+	if h.HostChange != "backend.internal" || h.Location != "/api" || h.PathRewrite != "/v1" {
+		t.Fatalf("host routing parse failed: %+v", h)
+	}
+	if !h.HttpsJustProxy || !h.AutoSSL || !h.AutoHttps || !h.AutoCORS || !h.CompatMode || !h.TargetIsHttps {
+		t.Fatalf("host bool fields parse failed: %+v", h)
+	}
+	if h.HeaderChange != "x-trace:trace\n" || h.RespHeaderChange != "x-server:nps\n" {
+		t.Fatalf("header change parse failed: header=%q response=%q", h.HeaderChange, h.RespHeaderChange)
+	}
+
+	health := dealHealth(`health_check_timeout=10
+health_check_max_failed=3
+health_check_interval=5
+health_http_url=/healthz
+health_check_type=http
+health_check_target=127.0.0.1:8080`)
+
+	if health.HealthCheckTimeout != 10 || health.HealthMaxFail != 3 || health.HealthCheckInterval != 5 {
+		t.Fatalf("health number fields parse failed: %+v", health)
+	}
+	if health.HttpHealthUrl != "/healthz" || health.HealthCheckType != "http" || health.HealthCheckTarget != "127.0.0.1:8080" {
+		t.Fatalf("health string fields parse failed: %+v", health)
+	}
+}
+
+func TestDealTunnelAndLocalService(t *testing.T) {
+	tunnel := dealTunnel(`server_port=9000-9001
+server_ip=0.0.0.0
+mode=tcp
+target_addr=127.0.0.1:9002,127.0.0.1:9003
+proxy_protocol=2
+target_port=10000
+target_ip=127.0.0.1
+password=pass
+socks5_proxy=true
+http_proxy=true
+dest_acl_mode=1
+dest_acl_rules=127.0.0.1:80,10.0.0.0/8:* 
+local_path=/tmp
+strip_pre=/api
+read_only=true`)
+
+	if tunnel.Ports != "9000-9001" || tunnel.ServerIp != "0.0.0.0" || tunnel.Mode != "tcp" {
+		t.Fatalf("tunnel basic fields parse failed: %+v", tunnel)
+	}
+	if tunnel.Target.TargetStr != "10000" || tunnel.TargetAddr != "127.0.0.1" {
+		t.Fatalf("tunnel target parse failed: %+v", tunnel)
+	}
+	if !tunnel.Socks5Proxy || !tunnel.HttpProxy || !tunnel.ReadOnly {
+		t.Fatalf("tunnel bool fields parse failed: %+v", tunnel)
+	}
+	if tunnel.DestAclMode != 1 || tunnel.DestAclRules != "127.0.0.1:80\n10.0.0.0/8:* " {
+		t.Fatalf("tunnel acl parse failed: %+v", tunnel)
+	}
+
+	local := delLocalService(`local_port=1080
+local_type=socks5
+local_ip=127.0.0.1
+password=123
+target_addr=127.0.0.1:8080
+target_type=tcp
+local_proxy=true
+fallback_secret=true`)
+	if local.Port != 1080 || local.Type != "socks5" || local.Ip != "127.0.0.1" {
+		t.Fatalf("local service basic fields parse failed: %+v", local)
+	}
+	if local.Password != "123" || local.Target != "127.0.0.1:8080" || local.TargetType != "tcp" {
+		t.Fatalf("local service route fields parse failed: %+v", local)
+	}
+	if !local.LocalProxy || !local.Fallback {
+		t.Fatalf("local service bool fields parse failed: %+v", local)
+	}
+}
+
+func TestDealMultiUserAndGetAllTitle(t *testing.T) {
+	users := dealMultiUser("#comment\nuser1=pass1\n user2 = pass2 \nuser3\n")
+	if len(users) != 3 {
+		t.Fatalf("unexpected user count: %d", len(users))
+	}
+	if users["user1"] != "pass1" || users["user2"] != "pass2" || users["user3"] != "" {
+		t.Fatalf("unexpected users map: %+v", users)
+	}
+
+	titles, err := getAllTitle("[common]\n[test]\n")
+	if err != nil {
+		t.Fatalf("getAllTitle should pass, err=%v", err)
+	}
+	if len(titles) != 2 || titles[0] != "[common]" || titles[1] != "[test]" {
+		t.Fatalf("unexpected titles: %+v", titles)
+	}
+
+	if _, err = getAllTitle("[common]\n[common]\n"); err == nil {
+		t.Fatalf("duplicate title should return error")
+	}
+}
+
+func TestNewConfig_ParseSections(t *testing.T) {
+	dir := t.TempDir()
+	multiUserPath := filepath.Join(dir, "multi_user.ini")
+	if err := os.WriteFile(multiUserPath, []byte("u1=p1\nu2=p2\n"), 0o644); err != nil {
+		t.Fatalf("write multi user file failed: %v", err)
+	}
+
+	content := `[common]
+server_addr=127.0.0.1:8284
+vkey=test-key
+conn_type=tcp
+
+[host-sec]
+host=example.com
+target_addr=127.0.0.1:8080
+multi_account=` + multiUserPath + `
+
+[tunnel-sec]
+mode=tcp
+server_port=9000
+target_addr=127.0.0.1:9001
+
+[health-check]
+health_check_timeout=10
+health_check_type=tcp
+
+[secret-demo]
+local_port=10080
+target_addr=127.0.0.1:1080
+
+[p2p-demo]
+target_addr=127.0.0.1:10000
+`
+
+	configPath := filepath.Join(dir, "nps.conf")
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config file failed: %v", err)
+	}
+
+	c, err := NewConfig(configPath)
+	if err != nil {
+		t.Fatalf("NewConfig failed: %v", err)
+	}
+	if c.CommonConfig == nil || c.CommonConfig.Server != "127.0.0.1:8284" || c.CommonConfig.VKey != "test-key" {
+		t.Fatalf("common section parse failed: %+v", c.CommonConfig)
+	}
+	if len(c.Hosts) != 1 || c.Hosts[0].Remark != "host-sec" || c.Hosts[0].MultiAccount.AccountMap["u1"] != "p1" {
+		t.Fatalf("host section parse failed: %+v", c.Hosts)
+	}
+	if len(c.Tasks) != 1 || c.Tasks[0].Remark != "tunnel-sec" || c.Tasks[0].Mode != "tcp" {
+		t.Fatalf("tunnel section parse failed: %+v", c.Tasks)
+	}
+	if len(c.Healths) != 1 || c.Healths[0].HealthCheckTimeout != 10 {
+		t.Fatalf("health section parse failed: %+v", c.Healths)
+	}
+	if len(c.LocalServer) != 2 {
+		t.Fatalf("local service section parse failed, len=%d", len(c.LocalServer))
+	}
+	if c.LocalServer[0].Type != "secret" || c.LocalServer[1].Type != "p2p" {
+		t.Fatalf("special section parse failed: %+v", c.LocalServer)
 	}
 }


### PR DESCRIPTION
### Motivation
- Increase test coverage and validate configuration parsing logic across diverse sections and edge cases.
- Ensure parsing functions correctly handle host, tunnel, health, local service, multi-account, and section/title behaviors.

### Description
- Added comprehensive unit tests in `lib/config/config_test.go` covering `dealHost`, `dealHealth`, `dealTunnel`, `delLocalService`, `dealMultiUser`, `getAllTitle`, and `NewConfig` parsing flows. 
- Tests exercise boolean flags, header/response header parsing, ACL rules normalization, multi-account file loading, duplicate-section error handling, and secret/p2p local-server section handling. 
- Introduced `os` and `path/filepath` imports to support temporary file creation for `multi_account` validation. 
- Assertions added to verify parsed field values, defaults, and error branches for malformed/duplicate titles.

### Testing
- Ran `go test ./lib/config -coverprofile=/tmp/config.cover && go tool cover -func=/tmp/config.cover` which reported `lib/config` coverage increased to **86.8%** (previously ~14.6%).
- Ran full test suite with `go test ./...` and all applicable packages passed their tests.

------
