### PR TITLE
perf(common): reduce allocations in address formatting paths

### DIFF
--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -149,9 +149,9 @@ func ValidateAddr(s string) string {
 
 func BuildAddress(host string, port string) string {
 	if strings.Contains(host, ":") { // IPv6
-		return fmt.Sprintf("[%s]:%s", host, port)
+		return "[" + host + "]:" + port
 	}
-	return fmt.Sprintf("%s:%s", host, port)
+	return host + ":" + port
 }
 
 func SplitServerAndPath(s string) (server, path string) {
@@ -895,14 +895,14 @@ func GetMatchingLocalAddr(remoteAddr, localAddr string) (string, error) {
 			return localAddr, fmt.Errorf("get local ipv6 addr: %w", err)
 		}
 		ip6 := tmpConn.LocalAddr().(*net.UDPAddr).IP.String()
-		return fmt.Sprintf("[%s]:%s", ip6, port), nil
+		return "[" + ip6 + "]:" + port, nil
 	} else {
 		tmpConn, err := GetLocalUdp4Addr()
 		if err != nil {
 			return localAddr, fmt.Errorf("get local ipv4 addr: %w", err)
 		}
 		ip4 := tmpConn.LocalAddr().(*net.UDPAddr).IP.String()
-		return fmt.Sprintf("%s:%s", ip4, port), nil
+		return ip4 + ":" + port, nil
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Reduce `fmt.Sprintf` allocation overhead in hot address-formatting paths while preserving exact output and behavior.

### Description
- Replace `fmt.Sprintf` with direct string concatenation in `BuildAddress` and `GetMatchingLocalAddr` to avoid transient allocations when composing IPv4/IPv6 `host:port` strings.

### Testing
- Ran `go test ./lib/common` and `go test ./...`, and all tests passed.

------
