### PR TITLE
perf(tool): optimize allow-port lookup using precomputed map

### DIFF
--- a/server/tool/utils.go
+++ b/server/tool/utils.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ports []int
+	portSet map[int]struct{}
 
 	statusCap  = 1440
 	ssMu       sync.RWMutex
@@ -41,6 +42,19 @@ func StartSystemInfo() {
 func InitAllowPort() {
 	p := beego.AppConfig.String("allow_ports")
 	ports = common.GetPorts(p)
+	buildAllowPortSet()
+}
+
+func buildAllowPortSet() {
+	if len(ports) == 0 {
+		portSet = nil
+		return
+	}
+	set := make(map[int]struct{}, len(ports))
+	for _, p := range ports {
+		set[p] = struct{}{}
+	}
+	portSet = set
 }
 
 func TestServerPort(p int, m string) (b bool) {
@@ -50,8 +64,10 @@ func TestServerPort(p int, m string) (b bool) {
 	if p > 65535 || p < 0 {
 		return false
 	}
-	if len(ports) != 0 && !common.InIntArr(ports, p) {
-		return false
+	if len(portSet) != 0 {
+		if _, ok := portSet[p]; !ok {
+			return false
+		}
 	}
 	if m == "udp" {
 		b = common.TestUdpPort(p)

--- a/server/tool/utils_test.go
+++ b/server/tool/utils_test.go
@@ -8,9 +8,12 @@ import (
 func withPorts(t *testing.T, p []int) {
 	t.Helper()
 	original := ports
+	originalSet := portSet
 	ports = p
+	buildAllowPortSet()
 	t.Cleanup(func() {
 		ports = original
+		portSet = originalSet
 	})
 }
 


### PR DESCRIPTION
### Motivation
- Reduce CPU overhead and memory churn during frequent port validation by avoiding repeated linear scans of the allow-list slice.
- Preserve existing validation logic and external behavior while improving lookup performance for large allow-port lists.

### Description
- Added a precomputed lookup `portSet map[int]struct{}` and helper `buildAllowPortSet()` in `server/tool/utils.go` and build it from parsed `ports` in `InitAllowPort()`.
- Replaced slice membership check in `TestServerPort()` (previously `common.InIntArr`) with an O(1) map lookup using `portSet` while keeping the original short-circuit order and bounds checks unchanged.
- Updated the test helper `withPorts` in `server/tool/utils_test.go` to rebuild `portSet` after injecting `ports` and to restore the original `portSet` during cleanup to maintain test isolation.
- No behavioral changes to `GenerateServerPort` or other logic that relies on the `ports` slice; `ports` is still preserved for ordering/random selection.

### Testing
- Ran `go test ./server/tool ./lib/common` and the tests passed (`ok` reported for both packages).

------
