### PR TITLE
test: add unit tests for TCP keepalive in lib/transport

### DIFF
--- a/lib/transport/transport_test.go
+++ b/lib/transport/transport_test.go
@@ -1,0 +1,81 @@
+//go:build !windows
+// +build !windows
+
+package transport
+
+import (
+	"net"
+	"testing"
+)
+
+func tcpPair(t *testing.T) (*net.TCPConn, *net.TCPConn, func()) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+
+	acceptCh := make(chan *net.TCPConn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			errCh <- acceptErr
+			return
+		}
+		tcpConn, ok := conn.(*net.TCPConn)
+		if !ok {
+			errCh <- net.InvalidAddrError("accepted connection is not *net.TCPConn")
+			_ = conn.Close()
+			return
+		}
+		acceptCh <- tcpConn
+	}()
+
+	clientRaw, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial tcp: %v", err)
+	}
+	client, ok := clientRaw.(*net.TCPConn)
+	if !ok {
+		_ = clientRaw.Close()
+		t.Fatal("dialed connection is not *net.TCPConn")
+	}
+
+	var server *net.TCPConn
+	select {
+	case server = <-acceptCh:
+	case err = <-errCh:
+		_ = client.Close()
+		t.Fatalf("accept tcp: %v", err)
+	}
+
+	cleanup := func() {
+		_ = client.Close()
+		_ = server.Close()
+		_ = ln.Close()
+	}
+	return client, server, cleanup
+}
+
+func TestSetTcpKeepAliveParamsSuccess(t *testing.T) {
+	client, _, cleanup := tcpPair(t)
+	defer cleanup()
+
+	if err := SetTcpKeepAliveParams(client, 10, 3, 5); err != nil {
+		t.Fatalf("expected keepalive params set successfully, got error: %v", err)
+	}
+}
+
+func TestSetTcpKeepAliveParamsOnClosedConn(t *testing.T) {
+	client, _, cleanup := tcpPair(t)
+	defer cleanup()
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("close client: %v", err)
+	}
+	if err := SetTcpKeepAliveParams(client, 10, 3, 5); err == nil {
+		t.Fatal("expected error on closed connection, got nil")
+	}
+}


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for the transport package by exercising the `SetTcpKeepAliveParams` helper which previously had no dedicated tests.
- Ensure both success and failure (closed connection) behaviors are validated so regressions in keepalive handling are caught early.

### Description

- Add a new test file `lib/transport/transport_test.go` with a non-Windows build tag `//go:build !windows` to match the implementation.
- Implement a reusable `tcpPair` helper that returns connected `*net.TCPConn` endpoints and a cleanup function.
- Add `TestSetTcpKeepAliveParamsSuccess` to verify `SetTcpKeepAliveParams` returns `nil` on a live TCP connection.
- Add `TestSetTcpKeepAliveParamsOnClosedConn` to verify an error is returned when the connection is closed.

### Testing

- Ran `go test ./lib/transport ./lib/conn ./web/routers` and the transport package tests passed.
- Ran `go test ./...` and the test suite completed successfully for packages with tests (non-test packages were skipped as expected).

------
