### PR TITLE
test: cover empty MinVersions branch in version helpers

### DIFF
--- a/lib/version/version_test.go
+++ b/lib/version/version_test.go
@@ -34,6 +34,23 @@ func TestVersionRangeHelpers(t *testing.T) {
 	}
 }
 
+func TestVersionRangeHelpers_EmptyMinVersions(t *testing.T) {
+	origin := MinVersions
+	defer func() { MinVersions = origin }()
+
+	MinVersions = nil
+
+	if got := GetCount(); got != 0 {
+		t.Fatalf("GetCount() = %d, want 0", got)
+	}
+	if got := GetLatest(); got != "" {
+		t.Fatalf("GetLatest() = %q, want empty string", got)
+	}
+	if got := GetLatestIndex(); got != 0 {
+		t.Fatalf("GetLatestIndex() = %d, want 0", got)
+	}
+}
+
 func TestGetMinVersion(t *testing.T) {
 	if got := GetMinVersion(true); got != MinVersions[MinVer] {
 		t.Fatalf("GetMinVersion(true) = %q, want %q", got, MinVersions[MinVer])


### PR DESCRIPTION
### Motivation
- Add a unit test to exercise defensive behavior when the `MinVersions` slice is empty so boundary branches in version helpers are covered.

### Description
- Add `TestVersionRangeHelpers_EmptyMinVersions` in `lib/version/version_test.go` which sets `MinVersions = nil` (with a deferred restore) and asserts `GetCount()` returns `0`, `GetLatest()` returns `""`, and `GetLatestIndex()` returns `0`.

### Testing
- Ran `go test ./lib/version -cover` which passed and reports `coverage: 100.0% of statements`.

------
