### PR TITLE
test: stabilize timeout TLS tests by reusing cert fixture

### DIFF
--- a/lib/conn/timeout_test.go
+++ b/lib/conn/timeout_test.go
@@ -16,6 +16,11 @@ import (
 	"time"
 )
 
+var (
+	testCertOnce sync.Once
+	testCert     tls.Certificate
+)
+
 type deadlineSpyConn struct {
 	net.Conn
 	mu            sync.Mutex
@@ -123,7 +128,7 @@ func TestTimeoutConnReadWriteSetsDeadline(t *testing.T) {
 }
 
 func TestNewTimeoutTLSConnSuccess(t *testing.T) {
-	cert := generateSelfSignedCert(t)
+	cert := testSelfSignedCert(t)
 
 	clientRaw, serverRaw := net.Pipe()
 	defer serverRaw.Close()
@@ -174,7 +179,7 @@ func TestNewTimeoutTLSConnSuccess(t *testing.T) {
 }
 
 func TestNewTimeoutTLSConnHandshakeFailureClosesRaw(t *testing.T) {
-	cert := generateSelfSignedCert(t)
+	cert := testSelfSignedCert(t)
 
 	clientRaw, serverRaw := net.Pipe()
 	spy := &closeSpyConn{Conn: clientRaw}
@@ -241,4 +246,12 @@ func generateSelfSignedCert(t *testing.T) tls.Certificate {
 		t.Fatalf("load key pair failed: %v", err)
 	}
 	return cert
+}
+
+func testSelfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	testCertOnce.Do(func() {
+		testCert = generateSelfSignedCert(t)
+	})
+	return testCert
 }


### PR DESCRIPTION
### Motivation
- Reduce repeated crypto setup and make TLS-related timeout tests faster and more stable while keeping them fully in-memory and independent of external systems.

### Description
- Add a package-level `sync.Once` shared fixture (`testSelfSignedCert`) in `lib/conn/timeout_test.go` and replace per-test `generateSelfSignedCert` calls with the shared helper.

### Testing
- Ran `go test ./lib/conn -count=1` and `go test ./... -count=1 -timeout=20s`, both completed successfully and no tests exceeded the 20s timeout.

------
