### PR TITLE
test: expand BaseServer unit test coverage

### DIFF
--- a/server/proxy/base_test.go
+++ b/server/proxy/base_test.go
@@ -1,9 +1,16 @@
 package proxy
 
 import (
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/djylb/nps/lib/common"
+	"github.com/djylb/nps/lib/conn"
 	"github.com/djylb/nps/lib/file"
 )
 
@@ -65,4 +72,122 @@ func TestCheckFlowAndConnNum(t *testing.T) {
 			t.Fatalf("client.NowConn = %d, want 1", client.NowConn)
 		}
 	})
+}
+
+func TestFlowAddAndFlowAddHost(t *testing.T) {
+	taskFlow := &file.Flow{}
+	hostFlow := &file.Flow{}
+	s := &BaseServer{Task: &file.Tunnel{Flow: taskFlow}}
+	h := &file.Host{Flow: hostFlow}
+
+	s.FlowAdd(10, 20)
+	s.FlowAddHost(h, 30, 40)
+
+	if taskFlow.InletFlow != 10 || taskFlow.ExportFlow != 20 {
+		t.Fatalf("task flow mismatch: inlet=%d export=%d", taskFlow.InletFlow, taskFlow.ExportFlow)
+	}
+	if hostFlow.InletFlow != 30 || hostFlow.ExportFlow != 40 {
+		t.Fatalf("host flow mismatch: inlet=%d export=%d", hostFlow.InletFlow, hostFlow.ExportFlow)
+	}
+}
+
+func TestAuth(t *testing.T) {
+	t.Run("auth success", func(t *testing.T) {
+		s := &BaseServer{}
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")))
+
+		if err := s.Auth(r, nil, "user", "pass", nil, nil); err != nil {
+			t.Fatalf("Auth() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("auth failure writes unauthorized bytes and closes conn", func(t *testing.T) {
+		s := &BaseServer{}
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("bad:creds")))
+
+		serverSide, clientSide := net.Pipe()
+		defer clientSide.Close()
+
+		c := conn.NewConn(serverSide)
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.Auth(r, c, "user", "pass", nil, nil)
+		}()
+
+		buf := make([]byte, len(common.UnauthorizedBytes))
+		if _, err := io.ReadFull(clientSide, buf); err != nil {
+			t.Fatalf("Read() unauthorized bytes error = %v", err)
+		}
+		if got := string(buf); got != common.UnauthorizedBytes {
+			t.Fatalf("unauthorized bytes = %q, want %q", got, common.UnauthorizedBytes)
+		}
+
+		err := <-errCh
+		if err == nil || err.Error() != "401 Unauthorized" {
+			t.Fatalf("Auth() error = %v, want 401 Unauthorized", err)
+		}
+	})
+}
+
+func TestWriteConnFail(t *testing.T) {
+	s := &BaseServer{ErrorContent: []byte("detail")}
+	serverSide, clientSide := net.Pipe()
+	defer clientSide.Close()
+
+	go s.writeConnFail(serverSide)
+
+	buf := make([]byte, len(common.ConnectionFailBytes)+len(s.ErrorContent))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	want := common.ConnectionFailBytes + "detail"
+	if got := string(buf); got != want {
+		t.Fatalf("writeConnFail() bytes = %q, want %q", got, want)
+	}
+
+	_ = serverSide.Close()
+}
+
+func TestCheckFlowAndConnNumAtTrafficLimitBoundary(t *testing.T) {
+	s := &BaseServer{}
+	client := &file.Client{Flow: &file.Flow{FlowLimit: 1, ExportFlow: 1 << 20, InletFlow: 0}, MaxConn: 2}
+
+	err := s.CheckFlowAndConnNum(client)
+	if err != nil {
+		t.Fatalf("CheckFlowAndConnNum() unexpected error = %v", err)
+	}
+	if client.NowConn != 1 {
+		t.Fatalf("client.NowConn = %d, want 1", client.NowConn)
+	}
+}
+
+func TestAuthWithMultiAccount(t *testing.T) {
+	s := &BaseServer{}
+	r := httptest.NewRequest("GET", "http://example.com", nil)
+	r.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("worker:p@ss")))
+	multi := &file.MultiAccount{AccountMap: map[string]string{"worker": "p@ss"}}
+
+	if err := s.Auth(r, nil, "", "", multi, nil); err != nil {
+		t.Fatalf("Auth() with multi-account unexpected error = %v", err)
+	}
+}
+
+func TestWriteConnFailWithNilErrorContent(t *testing.T) {
+	s := &BaseServer{}
+	serverSide, clientSide := net.Pipe()
+	defer clientSide.Close()
+
+	go s.writeConnFail(serverSide)
+
+	buf := make([]byte, len(common.ConnectionFailBytes))
+	if _, err := io.ReadFull(clientSide, buf); err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := string(buf); !strings.HasPrefix(got, common.ConnectionFailBytes) {
+		t.Fatalf("writeConnFail() bytes = %q, want prefix %q", got, common.ConnectionFailBytes)
+	}
+
+	_ = serverSide.Close()
 }


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for server/proxy BaseServer logic that was previously untested. 
- Exercise authentication branches, flow accounting, and connection-failure response behavior without touching external systems. 

### Description
- Add comprehensive tests in `server/proxy/base_test.go` that cover `FlowAdd`, `FlowAddHost`, `Auth` (success, failure, and multi-account), `writeConnFail` (with and without `ErrorContent`), and a traffic-limit boundary case for `CheckFlowAndConnNum`.
- Tests use in-process primitives (`net.Pipe`, `httptest.NewRequest`) and package helpers, and no external network or filesystem resources are used. 
- Only test code was changed (imports updated and new test functions added) and no production code was modified. 

### Testing
- Ran `go test ./server/proxy/...` and the package tests completed successfully. 
- Ran `go test ./server/proxy -cover` which completed successfully and reported coverage for the package.

------
