### PR TITLE
Fix pmux shutdown panic and harden unit tests

### DIFF
--- a/lib/pmux/pmux.go
+++ b/lib/pmux/pmux.go
@@ -76,8 +76,9 @@ func (pMux *PortMux) Start() error {
 			conn, err := pMux.Listener.Accept()
 			if err != nil {
 				logs.Warn("%v", err)
-				//close
+				// close and stop processing when listener is no longer available.
 				_ = pMux.Close()
+				return
 			}
 			go pMux.process(conn)
 		}
@@ -86,6 +87,9 @@ func (pMux *PortMux) Start() error {
 }
 
 func (pMux *PortMux) process(conn net.Conn) {
+	if conn == nil {
+		return
+	}
 	// Recognition according to different signs
 	// read 3 byte
 	buf := make([]byte, 3)
@@ -196,12 +200,31 @@ func (pMux *PortMux) Close() error {
 		return errors.New("the port pmux has closed")
 	}
 	pMux.isClose = true
-	close(pMux.clientConn)
-	close(pMux.clientTlsConn)
-	close(pMux.httpsConn)
-	close(pMux.httpConn)
-	close(pMux.managerConn)
-	return pMux.Listener.Close()
+	if pMux.clientConn != nil {
+		close(pMux.clientConn)
+	}
+	if pMux.clientTlsConn != nil {
+		close(pMux.clientTlsConn)
+	}
+	if pMux.clientWsConn != nil {
+		close(pMux.clientWsConn)
+	}
+	if pMux.clientWssConn != nil {
+		close(pMux.clientWssConn)
+	}
+	if pMux.httpsConn != nil {
+		close(pMux.httpsConn)
+	}
+	if pMux.httpConn != nil {
+		close(pMux.httpConn)
+	}
+	if pMux.managerConn != nil {
+		close(pMux.managerConn)
+	}
+	if pMux.Listener != nil {
+		return pMux.Listener.Close()
+	}
+	return nil
 }
 
 func parseHostHeader(line []byte) (string, bool) {

--- a/lib/pmux/pmux_test.go
+++ b/lib/pmux/pmux_test.go
@@ -50,3 +50,15 @@ func TestPortMux_ListenersAndClose(t *testing.T) {
 		t.Fatalf("close failed: %v", err)
 	}
 }
+
+func TestPortMux_CloseWithoutListeners(t *testing.T) {
+	pMux := &PortMux{}
+	if err := pMux.Close(); err != nil {
+		t.Fatalf("close without listeners failed: %v", err)
+	}
+}
+
+func TestPortMux_ProcessNilConn(t *testing.T) {
+	pMux := &PortMux{}
+	pMux.process(nil)
+}


### PR DESCRIPTION
### Motivation
- `go test -race ./...` revealed a panic in `lib/pmux` caused by `process` being called with a nil `net.Conn` during listener shutdown, resulting in a nil-pointer crash. 
- The shutdown path also attempted to close nil channels/listeners which could cause panics or undefined behavior in edge cases. 

### Description
- Stop the accept loop after an `Accept` error by returning from the goroutine to avoid dispatching a nil connection in `Start` (`PortMux.Start`). 
- Make `PortMux.process` tolerate a nil `conn` and return early to prevent nil dereference. 
- Make `PortMux.Close` nil-safe by only closing non-nil channels, add `clientWsConn`/`clientWssConn` to the closure list, and guard `Listener` closure. 
- Add unit tests `TestPortMux_CloseWithoutListeners` and `TestPortMux_ProcessNilConn` to cover closing an uninitialized `PortMux` and calling `process(nil)`. 

### Testing
- Ran `go test ./lib/pmux -count=1` and it passed. 
- Ran `go test -race ./lib/pmux -count=1` and it passed. 
- Ran full suite with `go test ./...` and it completed successfully.

------
