### PR TITLE
Fix go vet copylocks warning in lib/file test

### DIFF
--- a/lib/file/file_test.go
+++ b/lib/file/file_test.go
@@ -108,8 +108,8 @@ func TestStoreSyncMapToFileSkipsNoStoreEntries(t *testing.T) {
 	}
 
 	found := map[int]bool{}
-	for _, c := range clients {
-		found[c.Id] = true
+	for i := range clients {
+		found[clients[i].Id] = true
 	}
 	if !found[1] || !found[3] || found[2] {
 		t.Fatalf("unexpected persisted ids: %+v", found)


### PR DESCRIPTION
### Motivation
- `go vet` flagged a `range var ... copies lock` issue in `lib/file/file_test.go` because the test iterated over a slice of `Client` values that contain lock fields, causing value copies of locked structs.

### Description
- Change `TestStoreSyncMapToFileSkipsNoStoreEntries` in `lib/file/file_test.go` to iterate by index (`for i := range clients`) instead of by value to avoid copying `Client` values with locks, without altering test semantics.

### Testing
- Ran `go test ./...` which passed, and `go vet ./...]` which previously reported the warning and now completes with no issues.

------
