### PR TITLE
test(conn): 补充 util 超时与 TLS 连接测试

### DIFF
--- a/lib/conn/util_test.go
+++ b/lib/conn/util_test.go
@@ -8,6 +8,10 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"crypto/tls"
+
+	"github.com/djylb/nps/lib/crypt"
 )
 
 type fakeNetError struct {
@@ -43,17 +47,18 @@ func TestGetLenBytes(t *testing.T) {
 	}
 }
 
-func TestIsTempOrTimeout(t *testing.T) {
+func TestIsTimeout(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
 		want bool
 	}{
 		{name: "nil", err: nil, want: false},
-		{name: "net temporary", err: fakeNetError{msg: "temp", temporary: true}, want: true},
+		{name: "net temporary", err: fakeNetError{msg: "temp", temporary: true}, want: false},
 		{name: "net timeout", err: fakeNetError{msg: "timeout", timeout: true}, want: true},
-		{name: "plain timeout text", err: io.EOF, want: false},
-		{name: "plain timeout text", err: io.ErrNoProgress, want: false},
+		{name: "plain timeout text", err: errors.New("request timeout"), want: true},
+		{name: "plain non-timeout text", err: io.EOF, want: false},
+		{name: "plain non-timeout text", err: io.ErrNoProgress, want: false},
 		{name: "net.Error without timeout flag", err: &net.DNSError{Err: "i/o timeout"}, want: false},
 	}
 
@@ -63,6 +68,43 @@ func TestIsTempOrTimeout(t *testing.T) {
 				t.Fatalf("IsTimeout(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadACKTimeout(t *testing.T) {
+	server, client := net.Pipe()
+	defer func() { _ = server.Close() }()
+	defer func() { _ = client.Close() }()
+
+	err := ReadACK(client, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("ReadACK() error = nil, want timeout error")
+	}
+	if !IsTimeout(err) {
+		t.Fatalf("ReadACK() error = %v, want timeout-compatible error", err)
+	}
+}
+
+func TestGetTlsConn(t *testing.T) {
+	crypt.InitTls(tls.Certificate{})
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = serverConn.Close() }()
+	defer func() { _ = clientConn.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		tlsServer := crypt.NewTlsServerConn(serverConn)
+		errCh <- tlsServer.(*tls.Conn).Handshake()
+	}()
+
+	tlsClient, err := GetTlsConn(clientConn, "example.com:443")
+	if err != nil {
+		t.Fatalf("GetTlsConn() error = %v", err)
+	}
+	defer func() { _ = tlsClient.Close() }()
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("server TLS handshake error = %v", err)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- 修正并完善连接工具函数的测试覆盖，保证超时判断与 TLS 握手路径有自动化校验以符合现有实现。

### Description
- 修正 `IsTimeout` 的表驱动测试用例，调整对 `net.Error` temporary/timeout 行为的预期并增加基于错误文本的超时分支覆盖。
- 新增 `TestReadACKTimeout` 用于验证 `ReadACK` 在超时情况下返回可被 `IsTimeout` 识别的错误。
- 新增 `TestGetTlsConn`，使用 `net.Pipe` 与 `crypt` 封装的 TLS server/client 验证 `GetTlsConn` 握手成功。
- 变更文件：`lib/conn/util_test.go`。

### Testing
- 运行 `go test ./lib/conn` 并通过（测试成功）。
- 运行 `go test ./...` 并通过（所有包测试通过或无测试文件）。
- 运行 `go test -cover ./lib/conn` 并通过，生成覆盖率输出。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad01945a2c8331a5ba673b7cedf03c)