### PR TITLE
docs: refine quick-start instructions in README (zh/en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A high-performance NAT traversal and reverse proxy server with Web UI.
 
 ## Introduction
 
-NPS is a lightweight and efficient NAT traversal and reverse proxy system for exposing services behind NAT or firewall. It supports multiple protocols such as TCP, UDP, HTTP, HTTPS, and SOCKS5, and provides a Web management interface for convenient deployment and monitoring.
+NPS is a lightweight and efficient NAT traversal and reverse proxy system for exposing services behind NAT or firewalls. It supports multiple protocols such as TCP, UDP, HTTP, HTTPS, and SOCKS5, and provides a Web management interface for convenient deployment and monitoring.
 
 Since the original [NPS](https://github.com/ehang-io/nps) project has been inactive for a long time, this repository continues its development as an actively maintained community version with extensive refactoring, improved stability, and enhanced functionality.
 
@@ -33,7 +33,7 @@ Since the original [NPS](https://github.com/ehang-io/nps) project has been inact
 ## Key Features
 
 - **Multi-Protocol Support**  
-  Supports TCP/UDP forwarding, HTTP/HTTPS reverse proxy, HTTP/SOCKS5 proxy, P2P mode, Proxy Protocol support, HTTP/3 support, and more for different intranet access scenarios.
+  Supports TCP/UDP forwarding, HTTP/HTTPS reverse proxy, HTTP/SOCKS5 proxy, P2P mode, Proxy Protocol support, HTTP/3 support, and more for different private-network access scenarios.
 
 - **Cross-Platform Deployment**  
   Compatible with major platforms such as Linux and Windows, and can be easily installed as a system service.
@@ -42,7 +42,7 @@ Since the original [NPS](https://github.com/ehang-io/nps) project has been inact
   Provides real-time monitoring of traffic, connection status, and client states with an intuitive and user-friendly interface.
 
 - **Security and Extensibility**  
-  Built-in features such as encrypted transmission, traffic limiting, expiration restrictions, certificate management, and certificate renewal help improve security and manageability.
+  Built-in features such as encrypted transmission, traffic limiting, access expiration controls, certificate management, and certificate renewal help improve security and manageability.
 
 - **Multiple Connection Protocols**  
   Supports connecting to the server using TCP, KCP, TLS, QUIC, WS, and WSS protocols.
@@ -70,12 +70,16 @@ docker pull duan2001/nps
 docker run -d --restart=always --name nps --net=host -v $(pwd)/conf:/conf -v /etc/localtime:/etc/localtime:ro duan2001/nps
 ```
 
+> **Tip:** After installing NPS, edit `nps.conf` (for example: listening ports and Web admin credentials) before starting the service.
+
 #### NPC Client
 
 ```bash
 docker pull duan2001/npc
 docker run -d --restart=always --name npc --net=host duan2001/npc -server=xxx:123,yyy:456 -vkey=key1,key2 -type=tls,tcp -log=off
 ```
+
+> **Tip:** Get `-server`, `-vkey`, and `-type` from the client page in the NPS Web UI to avoid manual input mistakes.
 
 ### Server Installation
 
@@ -90,6 +94,8 @@ nps start|stop|restart|uninstall
 # Update
 nps update && nps restart
 ```
+
+> **Tip:** For first-time setup, edit `/etc/nps/nps.conf` and verify it before running `nps start`.
 
 #### Windows
 
@@ -117,6 +123,8 @@ npc start|stop|restart|uninstall
 # Update
 npc update && npc restart
 ```
+
+> **Tip:** For `npc install`, use the command generated on the client page in the NPS Web UI.
 
 #### Windows
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,11 +69,15 @@ docker pull duan2001/nps
 docker run -d --restart=always --name nps --net=host -v $(pwd)/conf:/conf -v /etc/localtime:/etc/localtime:ro duan2001/nps
 ```
 
+> **提示：** NPS 安装完成后，请先修改 `nps.conf`（如监听端口、Web 管理账号等）再启动服务。
+
 #### NPC 客户端
 ```bash
 docker pull duan2001/npc
 docker run -d --restart=always --name npc --net=host duan2001/npc -server=xxx:123,yyy:456 -vkey=key1,key2 -type=tls,tcp -log=off
 ```
+
+> **提示：** `-server`、`-vkey`、`-type` 等参数请从 NPS Web 管理端的客户端页面复制，避免手动填写错误。
 
 ### 服务端安装
 
@@ -87,6 +91,8 @@ nps start|stop|restart|uninstall
 # 更新
 nps update && nps restart
 ```
+
+> **提示：** 首次安装后请先编辑 `/etc/nps/nps.conf`，确认配置无误后再执行 `nps start`。
 
 #### Windows
 > Windows 7 用户请使用 old 结尾版本 [64](https://github.com/djylb/nps/releases/latest/download/windows_amd64_server_old.tar.gz) / [32](https://github.com/djylb/nps/releases/latest/download/windows_386_server_old.tar.gz)
@@ -111,6 +117,8 @@ npc start|stop|restart|uninstall
 # 更新
 npc update && npc restart
 ```
+
+> **提示：** `npc install` 命令中的参数请以 NPS Web 管理端客户端页面生成的命令为准。
 
 #### Windows
 > Windows 7 用户请使用 old 结尾版本 [64](https://github.com/djylb/nps/releases/latest/download/windows_amd64_client_old.tar.gz) / [32](https://github.com/djylb/nps/releases/latest/download/windows_386_client_old.tar.gz)


### PR DESCRIPTION
### Motivation
- Make the README quicker and safer for new users by adding minimal, high-value hints for starting the server and client.
- Remind users to update `nps.conf` after installing NPS and to obtain NPC parameters from the Web UI to avoid misconfiguration.

### Description
- Added a short tip to `README.md` telling users to edit `nps.conf` (e.g. listening ports and Web admin credentials) after installation and before starting the service.
- Added a short tip to `README.md` advising users to copy `-server`, `-vkey`, and `-type` from the NPS Web UI client page when starting NPC.
- Mirrored the same minimal tips into `README_zh.md` in Chinese, preserving original structure and keeping edits minimal.
- Lightly reworded a few English phrases for clarity (no functional or configuration defaults were changed).

### Testing
- Verified the changes by checking the repository diff for `README.md` and `README_zh.md` using `git diff -- README.md README_zh.md`, and the diff matches the intended small documentation updates (success).
- Previewed the edited sections with `nl -ba README.md | sed -n '12,140p'` and `nl -ba README_zh.md | sed -n '58,140p'` to confirm the inserted tips appear in the correct locations (success).
- Confirmed no other files or behavioral code were modified by reviewing the file list and diff (success).

------
