### PR TITLE
docs: clarify TOTP input order in nps config comment

### DIFF
--- a/conf/nps.conf
+++ b/conf/nps.conf
@@ -111,7 +111,7 @@ disconnect_timeout=30
 web_username=admin
 web_password=123
 # 2FA 双因素认证密钥 / TOTP secret
-# 启用后需输入 6 位动态码 / When enabled, append 6-digit OTP during login；"web_password" 留空可仅用 TOTP / leave "web_password" empty for TOTP-only login
+# 启用后登录时需在密码（或验证码）后追加 6 位动态码 / When enabled, append 6-digit OTP after password (or CAPTCHA) during login；"web_password" 留空可仅用 TOTP / leave "web_password" empty for TOTP-only login
 # 可用 "nps -gen2fa" 生成密钥 / Use "nps -gen2fa" to generate secret；"-gen2fa=secret" 获取当前动态码 / get current OTP
 totp_secret=
 # 开启管理面板验证码 / Enable CAPTCHA on admin login


### PR DESCRIPTION
### Motivation
- Reduce confusion about login input order when TOTP is enabled by making the config comment explicitly state where to append the 6-digit OTP.

### Description
- Updated the TOTP guidance comment in `conf/nps.conf` to state that the 6-digit OTP should be appended after the password (or CAPTCHA) during login.

### Testing
- Located TOTP-related references with `rg -n "totp|otp|验证码|password" conf README_zh.md docs` to ensure context consistency, which succeeded.
- Verified the updated lines using `nl -ba conf/nps.conf | sed -n '108,122p'`, confirming the new comment is present.
- Reviewed the file diff with `git diff -- conf/nps.conf` to confirm only the intended comment change was applied.

------
