### PR TITLE
conf: enable server local proxy by default and clarify ip_limit warning

### DIFF
--- a/conf/nps.conf
+++ b/conf/nps.conf
@@ -181,7 +181,7 @@ allow_time_limit=true
 # 客户端隧道数限制 / Max tunnels per client
 allow_tunnel_num_limit=true
 # 允许服务端本地代理 / Allow local proxy on server
-allow_local_proxy=false
+allow_local_proxy=true
 # 允许用户使用本地代理 / Allow user-side local proxy
 allow_user_local=false
 # 允许私密代理连任意地址 / Allow secret link to any target
@@ -194,7 +194,7 @@ allow_connection_num_limit=true
 allow_multi_ip=true
 # 系统负载监控显示 / Show system load info
 system_info_display=true
-# IP 访问限制 / IP access restriction（详见文档 / see docs）
+# IP 访问限制 / IP access restriction（详见文档；不清楚作用请勿开启 / see docs; leave disabled if unsure）
 #ip_limit=true
 
 #############################################


### PR DESCRIPTION
### Motivation
- Make server-local proxy allowed by default while explicitly warning administrators not to enable `ip_limit=true` unless they understand its effect.

### Description
- Update `conf/nps.conf` to set `allow_local_proxy=true` and modify the `ip_limit` comment to include a clear warning (added note: “不清楚作用请勿开启 / leave disabled if unsure”).

### Testing
- Ran `git diff --check`, which reported no issues and the change was committed successfully.

------
