### PR TITLE
Return non-zero exit code on Bridge startup failure

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -150,7 +150,7 @@ func StartNewServer(cnf *file.Tunnel, bridgeDisconnect int) {
 	go func() {
 		if err := Bridge.StartTunnel(); err != nil {
 			logs.Error("start server bridge error %v", err)
-			os.Exit(0)
+			os.Exit(1)
 		}
 	}()
 	if p, err := beego.AppConfig.Int("p2p_port"); err == nil {


### PR DESCRIPTION
### Motivation
- Ensure the server process reports a real failure when `Bridge.StartTunnel()` returns an error instead of exiting with status `0`, so supervisors/automation can detect startup failures.

### Description
- Change `os.Exit(0)` to `os.Exit(1)` in `StartNewServer` in `server/server.go` so the process exits non‑zero when bridge startup fails.

### Testing
- Ran `go test ./...` which completed successfully; and `go vet ./...` with no issues reported.

------
