### PR TITLE
fix: drain HTTP health-check response bodies to avoid connection leaks

### DIFF
--- a/client/health.go
+++ b/client/health.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -178,6 +179,7 @@ func (hc *HealthChecker) doCheck(h *file.Health) {
 			if getErr != nil {
 				err = getErr
 			} else {
+				_, _ = io.Copy(io.Discard, resp.Body)
 				if resp.StatusCode != http.StatusOK {
 					err = fmt.Errorf("unexpected status %d", resp.StatusCode)
 				}


### PR DESCRIPTION
### Motivation
- Health checks used `hc.client.Do` and closed `resp.Body` without draining it, which can prevent HTTP connection reuse and cause extra sockets/TIME_WAIT growth under repeated checks.

### Description
- Added `io` import and updated `HealthChecker.doCheck` to call `io.Copy(io.Discard, resp.Body)` before closing the body to ensure the transport can reuse keep-alive connections.

### Testing
- Ran `go test ./client -run "TestDoCheck|TestNewHealthChecker|TestStopAndDrain" -count=1` and the package tests passed.
- Ran `go test ./client` as a package sanity check and it completed successfully.

------
