### PR TITLE
Fix websocket listener shutdown race to prevent goroutine/socket leaks

### DIFF
--- a/lib/conn/websocket.go
+++ b/lib/conn/websocket.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/djylb/nps/lib/common"
@@ -88,9 +89,10 @@ func (c *WsConn) SetReadDeadline(t time.Time) error  { return c.Conn.SetReadDead
 func (c *WsConn) SetWriteDeadline(t time.Time) error { return c.Conn.SetWriteDeadline(t) }
 
 type httpListener struct {
-	acceptCh chan net.Conn
-	closeCh  chan struct{}
-	addr     net.Addr
+	acceptCh  chan net.Conn
+	closeCh   chan struct{}
+	addr      net.Addr
+	closeOnce sync.Once
 }
 
 func NewWSListener(base net.Listener, path, trustedIps, realIpHeader string) net.Listener {
@@ -116,7 +118,11 @@ func NewWSListener(base net.Listener, path, trustedIps, realIpHeader string) net
 		if common.IsTrustedProxy(trustedIps, r.RemoteAddr) {
 			c.RealIP = realIP
 		}
-		ch <- c
+		select {
+		case ch <- c:
+		case <-hl.closeCh:
+			_ = c.Close()
+		}
 	})
 	srv := &http.Server{Handler: mux}
 	go func() { _ = srv.Serve(base) }()
@@ -150,7 +156,11 @@ func NewWSSListener(base net.Listener, path string, cert tls.Certificate, truste
 		if common.IsTrustedProxy(trustedIps, r.RemoteAddr) {
 			c.RealIP = realIP
 		}
-		ch <- c
+		select {
+		case ch <- c:
+		case <-hl.closeCh:
+			_ = c.Close()
+		}
 	})
 	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
 	srv := &http.Server{Handler: mux, TLSConfig: tlsConfig}
@@ -172,7 +182,9 @@ func (hl *httpListener) Accept() (net.Conn, error) {
 }
 
 func (hl *httpListener) Close() error {
-	close(hl.closeCh)
+	hl.closeOnce.Do(func() {
+		close(hl.closeCh)
+	})
 	return nil
 }
 


### PR DESCRIPTION
### Motivation
- WebSocket upgrade handlers could block sending the accepted connection into `acceptCh` while the listener is closing, which can leave goroutines and sockets leaked and make repeated `Close()` calls unsafe.

### Description
- Add a `closeOnce sync.Once` field to `httpListener` and make `Close()` idempotent via `closeOnce.Do` to avoid panics from repeated closes.
- Change the upgrade handler to use a `select` when sending to `acceptCh`, and immediately close the upgraded connection if `closeCh` is already closed to avoid blocking goroutines.
- Add the `sync` import required for `sync.Once` and keep existing behavior of the WS listener otherwise unchanged.

### Testing
- Ran `gofmt -w lib/conn/websocket.go` successfully.
- Ran `go test ./lib/conn` and it passed.
- Ran `go test ./server/proxy` and it passed.
- Ran `go test ./...` and the test suite completed with all tested packages reporting `ok`.

------
