### PR TITLE
隧道有效期自定义页面返回

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ npc
 *.tar.gz
 *.json
 *.tmp
+*.zip
+*.bat
+*.ps1
+nps-linux-*
+nps-windows-*

--- a/conf/nps.conf
+++ b/conf/nps.conf
@@ -104,6 +104,16 @@ disconnect_timeout=30
 #allow_ports=9001-9009,10001,11000-12000
 
 #############################################
+# Customized return interface
+# 自定义返回界面
+#############################################
+# 设置时间有效期到期时返回界面
+toomanyrequests_page=web/static/page/toomanyrequests.html
+# 404返回界面
+error_page=web/static/page/error.html
+
+
+#############################################
 # Web Management Settings
 # Web 管理配置
 #############################################

--- a/server/proxy/httpproxy/http.go
+++ b/server/proxy/httpproxy/http.go
@@ -242,9 +242,72 @@ func (s *HttpServer) handleProxy(w http.ResponseWriter, r *http.Request) {
 			if idx == -1 {
 				idx = strings.Index(errMsg, "Client")
 			}
+
+			// 获取用户名和隧道名称
+			host, _ := r.Context().Value(ctxHost).(*file.Host)
+			clientName := ""
+			if host != nil && host.Client != nil && host.Client.Cnf != nil {
+				clientName = host.Client.Cnf.U
+			}
+			tunnelName := ""
+			if host != nil {
+				tunnelName = host.Host
+			}
+
+			// 获取隧道有效时间（剩余时间）
+			tunnelDuration := ""
+			if host != nil && host.Client != nil && host.Client.Flow != nil {
+				host.Client.Flow.RLock()
+				expireTime := host.Client.Flow.TimeLimit
+				host.Client.Flow.RUnlock()
+
+				if !expireTime.IsZero() {
+					now := time.Now()
+					duration := time.Until(expireTime)
+
+					if duration > 0 {
+						hours := int(duration.Hours())
+						minutes := int(duration.Minutes()) % 60
+						seconds := int(duration.Seconds()) % 60
+
+						if hours > 0 {
+							if minutes > 0 {
+								tunnelDuration = fmt.Sprintf("剩余 %d小时%d分钟", hours, minutes)
+							} else {
+								tunnelDuration = fmt.Sprintf("剩余 %d小时", hours)
+							}
+						} else if minutes > 0 {
+							if seconds > 0 {
+								tunnelDuration = fmt.Sprintf("剩余 %d分钟%d秒", minutes, seconds)
+							} else {
+								tunnelDuration = fmt.Sprintf("剩余 %d分钟", minutes)
+							}
+						} else {
+							tunnelDuration = fmt.Sprintf("剩余 %d秒", seconds)
+						}
+					} else {
+						tunnelDuration = "已过期"
+					}
+				}
+			}
+
 			if idx != -1 {
-				http.Error(rw, errMsg[idx:], http.StatusTooManyRequests)
+				// 用HTML替换占位符，显示隧道有效时间而不是原始错误信息
+				pageContent := string(s.TooManyRequestsPage)
+				pageContent = strings.ReplaceAll(pageContent, "{error}", tunnelDuration)
+				pageContent = strings.ReplaceAll(pageContent, "{username}", clientName)
+				pageContent = strings.ReplaceAll(pageContent, "{tunnel}", tunnelName)
+
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(pageContent))
 			} else {
+				// 其他错误返回502
+				//http.Error(rw, "502 Bad Gateway", http.StatusBadGateway)
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write(s.ErrorContent)
+			}
 				//http.Error(rw, "502 Bad Gateway", http.StatusBadGateway)
 				w.Header().Set("Content-Type", "text/html; charset=utf-8")
 				w.WriteHeader(http.StatusBadGateway)

--- a/server/proxy/httpproxy/http.go
+++ b/server/proxy/httpproxy/http.go
@@ -238,95 +238,48 @@ func (s *HttpServer) handleProxy(w http.ResponseWriter, r *http.Request) {
 			logs.Debug("ErrorHandler: proxy error: method=%s, URL=%s, error=%v", req.Method, req.URL.String(), err)
 
 			errMsg := err.Error()
+			// logs.Debug("ErrorHandler: 我这是报错内容: %s", errMsg)
+			//  ErrorHandler: 我这是报错内容: net/http: HTTP/1.x transport connection broken: Task: time limit exceeded
+			// ErrorHandler: 我这是报错内容: net/http: HTTP/1.x transport connection broken: Task: flow limit exceeded
 			idx := strings.Index(errMsg, "Task")
 			if idx == -1 {
 				idx = strings.Index(errMsg, "Client")
 			}
 
-			// 获取用户名和隧道名称
-			host, _ := r.Context().Value(ctxHost).(*file.Host)
-			clientName := ""
-			if host != nil && host.Client != nil && host.Client.Cnf != nil {
-				clientName = host.Client.Cnf.U
-			}
-			tunnelName := ""
-			if host != nil {
-				tunnelName = host.Host
-			}
-
-			// 获取隧道有效时间（剩余时间）
-			tunnelDuration := ""
-			if host != nil && host.Client != nil && host.Client.Flow != nil {
-				host.Client.Flow.RLock()
-				expireTime := host.Client.Flow.TimeLimit
-				host.Client.Flow.RUnlock()
-
-				if !expireTime.IsZero() {
-					now := time.Now()
-					duration := time.Until(expireTime)
-
-					if duration > 0 {
-						hours := int(duration.Hours())
-						minutes := int(duration.Minutes()) % 60
-						seconds := int(duration.Seconds()) % 60
-
-						if hours > 0 {
-							if minutes > 0 {
-								tunnelDuration = fmt.Sprintf("剩余 %d小时%d分钟", hours, minutes)
-							} else {
-								tunnelDuration = fmt.Sprintf("剩余 %d小时", hours)
-							}
-						} else if minutes > 0 {
-							if seconds > 0 {
-								tunnelDuration = fmt.Sprintf("剩余 %d分钟%d秒", minutes, seconds)
-							} else {
-								tunnelDuration = fmt.Sprintf("剩余 %d分钟", minutes)
-							}
-						} else {
-							tunnelDuration = fmt.Sprintf("剩余 %d秒", seconds)
-						}
-					} else {
-						tunnelDuration = "已过期"
-					}
-				}
-			}
-
 			if idx != -1 {
-				// 用HTML替换占位符，显示隧道有效时间而不是原始错误信息
-				pageContent := string(s.TooManyRequestsPage)
-				pageContent = strings.ReplaceAll(pageContent, "{error}", tunnelDuration)
-				pageContent = strings.ReplaceAll(pageContent, "{username}", clientName)
-				pageContent = strings.ReplaceAll(pageContent, "{tunnel}", tunnelName)
+				// 提取 Task/Client 后面的具体错误内容
+				errorDetail := errMsg[idx:]
+				
+				// 提取冒号后的内容
+				if colonIdx := strings.Index(errorDetail, ":"); colonIdx != -1 && len(errorDetail) > colonIdx+2 {
+					errorDetail = strings.TrimSpace(errorDetail[colonIdx+1:])
+				}
+				
+				// 使用启动时加载的 HTML 模板字符串（避免每次请求都转换）
+				pageContent := s.TooManyRequestsTpl
+				// 替换占位符，如果 HTML 中没有这些占位符，strings.ReplaceAll 会返回原字符串
+				pageContent = strings.ReplaceAll(pageContent, "{error}", errorDetail)
 
-				w.Header().Set("Content-Type", "text/html; charset=utf-8")
-				w.WriteHeader(http.StatusTooManyRequests)
-				_, _ = w.Write([]byte(pageContent))
+				rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+				rw.WriteHeader(http.StatusTooManyRequests)
+				_, _ = rw.Write([]byte(pageContent))
 			} else {
-				// 其他错误返回502
 				//http.Error(rw, "502 Bad Gateway", http.StatusBadGateway)
-				w.Header().Set("Content-Type", "text/html; charset=utf-8")
-				w.WriteHeader(http.StatusBadGateway)
-				_, _ = w.Write(s.ErrorContent)
-			}
-				//http.Error(rw, "502 Bad Gateway", http.StatusBadGateway)
-				w.Header().Set("Content-Type", "text/html; charset=utf-8")
-				w.WriteHeader(http.StatusBadGateway)
-				_, _ = w.Write(s.ErrorContent)
+				rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+				rw.WriteHeader(http.StatusBadGateway)
+				_, _ = rw.Write(s.ErrorContent)
 			}
 		},
 	}
+
 	rp.ServeHTTP(w, r)
 }
 
 func (s *HttpServer) handleWebsocket(w http.ResponseWriter, r *http.Request, host *file.Host, isHttpOnlyRequest bool) {
-	// Get target addr
 	targetAddr, err := host.Target.GetRandomTarget()
 	if err != nil {
-		logs.Warn("No backend found for host: %s Err: %v", r.Host, err)
-		//http.Error(w, "502 Bad Gateway", http.StatusBadGateway)
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write(s.ErrorContent)
+		logs.Warn("No backend found for h: %d Err: %v", host.Id, err)
+		http.Error(w, "502 Bad Gateway", http.StatusBadGateway)
 		return
 	}
 

--- a/server/proxy/httpproxy/httpproxy.go
+++ b/server/proxy/httpproxy/httpproxy.go
@@ -41,7 +41,8 @@ type HttpProxy struct {
 	Magic                 *certmagic.Config
 	Acme                  *certmagic.ACMEIssuer
 	ResponseHeaderTimeout time.Duration
-	TooManyRequestsPage  []byte // 429错误页面
+	TooManyRequestsPage   []byte // 429错误页面模板（启动时加载）
+	TooManyRequestsTpl    string // 429错误页面模板字符串（启动时加载）
 }
 
 func NewHttpProxy(bridge proxy.NetBridge, task *file.Tunnel, httpPort, httpsPort, http3Port int, httpOnlyPass string, addOrigin, allowLocalProxy bool, httpProxyCache *index.AnyIntIndex) *HttpProxy {
@@ -76,6 +77,8 @@ func (s *HttpProxy) Start() error {
 	if err != nil {
 		s.TooManyRequestsPage = []byte("nps 429")
 	}
+	// 将模板转为字符串，方便后续替换
+	s.TooManyRequestsTpl = string(s.TooManyRequestsPage)
 
 	if s.Bridge.IsServer() {
 		s.Http3Bridge = beego.AppConfig.DefaultBool("bridge_http3", true)

--- a/server/proxy/httpproxy/httpproxy.go
+++ b/server/proxy/httpproxy/httpproxy.go
@@ -41,6 +41,7 @@ type HttpProxy struct {
 	Magic                 *certmagic.Config
 	Acme                  *certmagic.ACMEIssuer
 	ResponseHeaderTimeout time.Duration
+	TooManyRequestsPage  []byte // 429错误页面
 }
 
 func NewHttpProxy(bridge proxy.NetBridge, task *file.Tunnel, httpPort, httpsPort, http3Port int, httpOnlyPass string, addOrigin, allowLocalProxy bool, httpProxyCache *index.AnyIntIndex) *HttpProxy {
@@ -69,6 +70,12 @@ func (s *HttpProxy) Start() error {
 		s.ErrorContent = []byte("nps 404")
 	}
 	s.ErrorAlways = beego.AppConfig.DefaultBool("error_always", false)
+
+	// 加载429错误页面
+	s.TooManyRequestsPage, err = common.ReadAllFromFile(common.ResolvePath(beego.AppConfig.DefaultString("toomanyrequests_page", "web/static/page/toomanyrequests.html")))
+	if err != nil {
+		s.TooManyRequestsPage = []byte("nps 429")
+	}
 
 	if s.Bridge.IsServer() {
 		s.Http3Bridge = beego.AppConfig.DefaultBool("bridge_http3", true)

--- a/web/static/page/toomanyrequests.html
+++ b/web/static/page/toomanyrequests.html
@@ -1,72 +1,23 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <meta charset="utf-8">
-    <title>请求过多 - {tunnel}</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
-            text-align: center;
-            padding: 60px 20px;
-            background-color: #f5f7fa;
-        }
-        .error-box {
-            background-color: white;
-            padding: 50px 30px;
-            border-radius: 12px;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
-            max-width: 500px;
-            margin: 0 auto;
-        }
-        .error-code {
-            font-size: 80px;
-            font-weight: bold;
-            color: #e74c3c;
-            line-height: 1;
-            margin-bottom: 10px;
-        }
-        .error-title {
-            font-size: 28px;
-            color: #2c3e50;
-            margin-bottom: 15px;
-            font-weight: 600;
-        }
-        .error-message {
-            font-size: 18px;
-            color: #7f8c8d;
-            margin-bottom: 30px;
-        }
-        .error-detail {
-            background-color: #f8f9fa;
-            padding: 15px;
-            border-radius: 8px;
-            margin-bottom: 20px;
-        }
-        .error-detail strong {
-            color: #3498db;
-        }
-        .user-info {
-            color: #95a5a6;
-            font-size: 14px;
-            margin-top: 25px;
-        }
-        .user-info span {
-            margin: 0 10px;
-        }
-    </style>
 </head>
+
 <body>
-    <div class="error-box">
-        <div class="error-code">429</div>
-        <div class="error-title">请求过多</div>
-        <div class="error-message">⚠️ 隧道已到期或请求过于频繁</div>
-        <div class="error-detail">
-            <p>隧道剩余有效时间: <strong>{error}</strong></p>
-        </div>
-        <div class="user-info">
-            <span>👤 用户: {username}</span>
-            <span>🌐 隧道: {tunnel}</span>
-        </div>
-    </div>
+    <p id="msg"></p>
+    <script>
+        var e = "{error}";
+        var m = document.getElementById("msg");
+        if (e.indexOf("time limit exceeded") !== -1) {
+            m.textContent = "Tunnel expired (time limit exceeded)";
+        } else if (e.indexOf("flow limit exceeded") !== -1) {
+            m.textContent = "Tunnel flow limit exceeded";
+        } else {
+            m.textContent = e;
+        }
+    </script>
 </body>
+
 </html>

--- a/web/static/page/toomanyrequests.html
+++ b/web/static/page/toomanyrequests.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>请求过多 - {tunnel}</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+            text-align: center;
+            padding: 60px 20px;
+            background-color: #f5f7fa;
+        }
+        .error-box {
+            background-color: white;
+            padding: 50px 30px;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+            max-width: 500px;
+            margin: 0 auto;
+        }
+        .error-code {
+            font-size: 80px;
+            font-weight: bold;
+            color: #e74c3c;
+            line-height: 1;
+            margin-bottom: 10px;
+        }
+        .error-title {
+            font-size: 28px;
+            color: #2c3e50;
+            margin-bottom: 15px;
+            font-weight: 600;
+        }
+        .error-message {
+            font-size: 18px;
+            color: #7f8c8d;
+            margin-bottom: 30px;
+        }
+        .error-detail {
+            background-color: #f8f9fa;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+        .error-detail strong {
+            color: #3498db;
+        }
+        .user-info {
+            color: #95a5a6;
+            font-size: 14px;
+            margin-top: 25px;
+        }
+        .user-info span {
+            margin: 0 10px;
+        }
+    </style>
+</head>
+<body>
+    <div class="error-box">
+        <div class="error-code">429</div>
+        <div class="error-title">请求过多</div>
+        <div class="error-message">⚠️ 隧道已到期或请求过于频繁</div>
+        <div class="error-detail">
+            <p>隧道剩余有效时间: <strong>{error}</strong></p>
+        </div>
+        <div class="user-info">
+            <span>👤 用户: {username}</span>
+            <span>🌐 隧道: {tunnel}</span>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
- Add TooManyRequestsPage field to HttpProxy struct
- Load 429 error page from external file with custom path support
- Display tunnel remaining time instead of original error message
- Support placeholders {error}, {username}, {tunnel} in error page template
- Add configuration item toomanyrequests_page in nps.conf

### 主要改动

1. **支持自定义错误页面路径**
   - 添加配置项 `toomanyrequests_page`
   - 默认路径：`web/static/page/toomanyrequests.html`

2. **显示隧道剩余时间**
   - 不再显示原始错误信息 "time limit exceeded"
   - 自动计算并显示剩余小时、分钟、秒

3. **自定义错误页面**
   - 支持占位符：`{error}`, `{username}`, `{tunnel}`
   - 提供现代化的 HTML 样式

### 使用方法

在 `conf/nps.conf` 中添加：
```ini
toomanyrequests_page=web/static/page/toomanyrequests.html
预览
当隧道超时时，会显示自定义错误页面：

✅ 隧道剩余有效时间
✅ 用户名
✅ 隧道名称